### PR TITLE
9580 skip purging enrollments referenced by a CE referral

### DIFF
--- a/app/jobs/purge_soft_deleted_records_job.rb
+++ b/app/jobs/purge_soft_deleted_records_job.rb
@@ -38,10 +38,12 @@ class PurgeSoftDeletedRecordsJob < BaseJob
       @retain_at = retain_at
       @dry_run = dry_run
       catch(:halt) do
-        data_sources.order(:id).each do |data_source|
-          models.each do |model|
-            model.unscoped do
-              process_model(model, data_source: data_source)
+        models.each do |model|
+          model.unscoped do
+            if scoped_by_data_source?(model)
+              data_sources.order(:id).each { |data_source| process_model(model, data_source: data_source) }
+            else
+              process_model(model)
             end
           end
         end
@@ -80,10 +82,20 @@ class PurgeSoftDeletedRecordsJob < BaseJob
       Hmis::Hud::CustomClientContactPoint,
       Hmis::Hud::CustomClientName,
       Hmis::Hud::CustomDataElement,
+      # CE referrals; dependents first
+      Hmis::Ce::ReferralNote,
+      Hmis::Ce::ReferralParticipant,
+      Hmis::Ce::Referral,
       # purge these last
       GrdaWarehouse::Hud::Enrollment,
       GrdaWarehouse::Hud::Client,
     ]
+  end
+
+  # CE referrals and their dependents reach their data source only through several paranoid joins, so they're
+  # purged across all data sources at once
+  def scoped_by_data_source?(model)
+    model.column_names.include?('data_source_id')
   end
 
   # tables with FK relationships need to be deleted. Choosing to leave other dangling references to client
@@ -101,26 +113,40 @@ class PurgeSoftDeletedRecordsJob < BaseJob
     ]
   end
 
+  # CE referrals hold FKs to Enrollment on target_enrollment_id and source_enrollment_id. Drop those references
+  # before the enrollments go; the referrals themselves are purged on their own retention date.
+  # Referrals are paranoid, and a soft-deleted referral still holds the foreign key, so include those here.
+  def clear_enrollment_references(enrollment_scope)
+    return if @dry_run
+
+    enrollment_ids = enrollment_scope.pluck(:id)
+    referrals = Hmis::Ce::Referral.with_deleted
+    referrals.where(target_enrollment_id: enrollment_ids).update_all(target_enrollment_id: nil)
+    referrals.where(source_enrollment_id: enrollment_ids).update_all(source_enrollment_id: nil)
+  end
+
+  def delete_dependents(dependent_scopes)
+    dependent_scopes.each do |dependent_scope|
+      check_max_deleted(dependent_scope.size)
+      dependent_scope.delete_all unless @dry_run
+    end
+  end
+
   def with_lock(&block)
     lock_name = self.class.name.demodulize
     GrdaWarehouseBase.with_advisory_lock(lock_name, timeout_seconds: 0, &block)
   end
 
-  def process_model(model, data_source:)
+  def process_model(model, data_source: nil)
     arel = model.arel_table
     paranoia_col = arel[model.paranoia_column.to_sym]
-    scope = model.
-      where(data_source: data_source).
-      where(paranoia_col.lt(@retain_at))
+    scope = model.where(paranoia_col.lt(@retain_at))
+    scope = scope.where(data_source: data_source) if data_source
 
     scope.in_batches(of: 5_000).each do |batch|
       model.transaction do
-        if model == GrdaWarehouse::Hud::Client
-          client_dependents(batch).each do |dependent_scope|
-            check_max_deleted(dependent_scope.size)
-            dependent_scope.delete_all unless @dry_run
-          end
-        end
+        delete_dependents(client_dependents(batch)) if model == GrdaWarehouse::Hud::Client
+        clear_enrollment_references(batch) if model == GrdaWarehouse::Hud::Enrollment
 
         # even though this throws, it does not rollback the transaction so we could delete more records than the max
         check_max_deleted(batch.size)

--- a/app/jobs/purge_soft_deleted_records_job.rb
+++ b/app/jobs/purge_soft_deleted_records_job.rb
@@ -38,12 +38,10 @@ class PurgeSoftDeletedRecordsJob < BaseJob
       @retain_at = retain_at
       @dry_run = dry_run
       catch(:halt) do
-        models.each do |model|
-          model.unscoped do
-            if scoped_by_data_source?(model)
-              data_sources.order(:id).each { |data_source| process_model(model, data_source: data_source) }
-            else
-              process_model(model)
+        data_sources.order(:id).each do |data_source|
+          models.each do |model|
+            model.unscoped do
+              process_model(model, data_source: data_source)
             end
           end
         end
@@ -82,24 +80,10 @@ class PurgeSoftDeletedRecordsJob < BaseJob
       Hmis::Hud::CustomClientContactPoint,
       Hmis::Hud::CustomClientName,
       Hmis::Hud::CustomDataElement,
-      # CE referrals; dependents first
-      Hmis::Ce::ReferralNote,
-      Hmis::Ce::ReferralParticipant,
-      Hmis::Ce::Referral,
-      # the workflow instance behind a CE referral, once the referral that holds the FK to it is gone
-      Hmis::WorkflowExecution::StepAssignment,
-      Hmis::WorkflowExecution::Step,
-      Hmis::WorkflowExecution::Instance,
       # purge these last
       GrdaWarehouse::Hud::Enrollment,
       GrdaWarehouse::Hud::Client,
     ]
-  end
-
-  # CE referrals and their dependents reach their data source only through several paranoid joins, so they're
-  # purged across all data sources at once
-  def scoped_by_data_source?(model)
-    model.column_names.include?('data_source_id')
   end
 
   # tables with FK relationships need to be deleted. Choosing to leave other dangling references to client
@@ -117,33 +101,17 @@ class PurgeSoftDeletedRecordsJob < BaseJob
     ]
   end
 
-  # CE referrals hold FKs to Enrollment on target_enrollment_id and source_enrollment_id. Drop those references
-  # before the enrollments go; the referrals themselves are purged on their own retention date.
-  # Referrals are paranoid, and a soft-deleted referral still holds the foreign key, so include those here.
-  def clear_enrollment_references(enrollment_scope)
-    return if @dry_run
-
-    enrollment_ids = enrollment_scope.pluck(:id)
+  # CE referrals hold FKs to enrollments (target_enrollment_id, source_enrollment_id), and a soft-deleted
+  # referral still holds them. Skip those enrollments rather than untangling the referral graph.
+  #
+  # FUTURE: these enrollments are never purged, since nothing purges CE referrals or the workflow execution
+  # records behind them. Rare enough today to leave; a full fix means adding referrals, their notes and
+  # participants, and the workflow instance/step/assignment/audit-event tree to the purge in dependency order.
+  def exclude_ce_referral_enrollments(enrollment_scope)
     referrals = Hmis::Ce::Referral.with_deleted
-    referrals.where(target_enrollment_id: enrollment_ids).update_all(target_enrollment_id: nil)
-    referrals.where(source_enrollment_id: enrollment_ids).update_all(source_enrollment_id: nil)
-  end
-
-  # wfe_audit_events is not paranoid, so audit events never get a deleted_at of their own to age out on. They
-  # hold FKs to both the step and the instance, so delete them with whichever one is being purged.
-  def workflow_step_dependents(step_scope)
-    [Hmis::WorkflowExecution::AuditEvent.where(step_id: step_scope.pluck(:id))]
-  end
-
-  def workflow_instance_dependents(instance_scope)
-    [Hmis::WorkflowExecution::AuditEvent.where(instance_id: instance_scope.pluck(:id))]
-  end
-
-  def delete_dependents(dependent_scopes)
-    dependent_scopes.each do |dependent_scope|
-      check_max_deleted(dependent_scope.size)
-      dependent_scope.delete_all unless @dry_run
-    end
+    enrollment_scope.
+      where.not(id: referrals.where.not(target_enrollment_id: nil).select(:target_enrollment_id)).
+      where.not(id: referrals.where.not(source_enrollment_id: nil).select(:source_enrollment_id))
   end
 
   def with_lock(&block)
@@ -151,18 +119,23 @@ class PurgeSoftDeletedRecordsJob < BaseJob
     GrdaWarehouseBase.with_advisory_lock(lock_name, timeout_seconds: 0, &block)
   end
 
-  def process_model(model, data_source: nil)
+  def process_model(model, data_source:)
     arel = model.arel_table
     paranoia_col = arel[model.paranoia_column.to_sym]
-    scope = model.where(paranoia_col.lt(@retain_at))
-    scope = scope.where(data_source: data_source) if data_source
+    scope = model.
+      where(data_source: data_source).
+      where(paranoia_col.lt(@retain_at))
+    # Hmis::Hud::Enrollment and GrdaWarehouse::Hud::Enrollment back the same table, so match on the table name
+    scope = exclude_ce_referral_enrollments(scope) if model.table_name == GrdaWarehouse::Hud::Enrollment.table_name
 
     scope.in_batches(of: 5_000).each do |batch|
       model.transaction do
-        delete_dependents(client_dependents(batch)) if model == GrdaWarehouse::Hud::Client
-
-
-        clear_enrollment_references(batch) if model == GrdaWarehouse::Hud::Enrollment
+        if model == GrdaWarehouse::Hud::Client
+          client_dependents(batch).each do |dependent_scope|
+            check_max_deleted(dependent_scope.size)
+            dependent_scope.delete_all unless @dry_run
+          end
+        end
 
         # even though this throws, it does not rollback the transaction so we could delete more records than the max
         check_max_deleted(batch.size)

--- a/app/jobs/purge_soft_deleted_records_job.rb
+++ b/app/jobs/purge_soft_deleted_records_job.rb
@@ -86,6 +86,10 @@ class PurgeSoftDeletedRecordsJob < BaseJob
       Hmis::Ce::ReferralNote,
       Hmis::Ce::ReferralParticipant,
       Hmis::Ce::Referral,
+      # the workflow instance behind a CE referral, once the referral that holds the FK to it is gone
+      Hmis::WorkflowExecution::StepAssignment,
+      Hmis::WorkflowExecution::Step,
+      Hmis::WorkflowExecution::Instance,
       # purge these last
       GrdaWarehouse::Hud::Enrollment,
       GrdaWarehouse::Hud::Client,
@@ -125,6 +129,16 @@ class PurgeSoftDeletedRecordsJob < BaseJob
     referrals.where(source_enrollment_id: enrollment_ids).update_all(source_enrollment_id: nil)
   end
 
+  # wfe_audit_events is not paranoid, so audit events never get a deleted_at of their own to age out on. They
+  # hold FKs to both the step and the instance, so delete them with whichever one is being purged.
+  def workflow_step_dependents(step_scope)
+    [Hmis::WorkflowExecution::AuditEvent.where(step_id: step_scope.pluck(:id))]
+  end
+
+  def workflow_instance_dependents(instance_scope)
+    [Hmis::WorkflowExecution::AuditEvent.where(instance_id: instance_scope.pluck(:id))]
+  end
+
   def delete_dependents(dependent_scopes)
     dependent_scopes.each do |dependent_scope|
       check_max_deleted(dependent_scope.size)
@@ -146,6 +160,8 @@ class PurgeSoftDeletedRecordsJob < BaseJob
     scope.in_batches(of: 5_000).each do |batch|
       model.transaction do
         delete_dependents(client_dependents(batch)) if model == GrdaWarehouse::Hud::Client
+
+
         clear_enrollment_references(batch) if model == GrdaWarehouse::Hud::Enrollment
 
         # even though this throws, it does not rollback the transaction so we could delete more records than the max

--- a/spec/jobs/purge_soft_deleted_records_job_spec.rb
+++ b/spec/jobs/purge_soft_deleted_records_job_spec.rb
@@ -79,4 +79,152 @@ RSpec.describe PurgeSoftDeletedRecordsJob, type: :job do
       expect(HmisExternalApis::AcHmis::ReferralHouseholdMember.exists?(referral_member_active.id)).to be true
     end
   end
+
+  describe '#perform on enrollments' do
+    let!(:ce_referral) { create(:hmis_ce_referral) }
+    let!(:referral_note) { create(:hmis_ce_referral_note, referral: ce_referral) }
+    let!(:referral_participant) { create(:hmis_ce_referral_participant, referral: ce_referral) }
+
+    # the target enrollment must be in the referral's project, the source enrollment need not be
+    let(:target_enrollment) do
+      create(
+        :hmis_hud_enrollment,
+        data_source: ce_referral.data_source,
+        project: ce_referral.target_project,
+        date_deleted: target_date_deleted,
+      )
+    end
+    let(:source_enrollment) do
+      create(:hmis_hud_enrollment, data_source: ce_referral.data_source, date_deleted: source_date_deleted)
+    end
+
+    let(:old) { today - 2.years }
+    let(:recent) { today - 2.months }
+
+    # Enrollment declares dependent: :destroy only on the source side (has_many :outgoing_ce_referrals), so a
+    # referral pointing at a soft-deleted enrollment is frequently still live itself
+    let(:referral_soft_deleted) { true }
+
+    before do
+      ce_referral.update!(target_enrollment: target_enrollment, source_enrollment: source_enrollment)
+      # a soft-deleted referral still holds the foreign key
+      ce_referral.destroy! if referral_soft_deleted
+    end
+
+    def run_purge
+      described_class.new.perform(
+        retain_at: today - 1.year,
+        models: [GrdaWarehouse::Hud::Enrollment],
+        dry_run: false,
+      )
+    end
+
+    context 'when both enrollments are purged' do
+      let(:target_date_deleted) { old }
+      let(:source_date_deleted) { old }
+
+      it 'clears both references and leaves the referral to its own retention date' do
+        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-2)
+
+        expect(Hmis::Ce::Referral.with_deleted.exists?(ce_referral.id)).to be true
+        ce_referral.reload
+        expect(ce_referral.target_enrollment_id).to be_nil
+        expect(ce_referral.source_enrollment_id).to be_nil
+      end
+    end
+
+    context 'when only the target enrollment is purged' do
+      let(:target_date_deleted) { old }
+      let(:source_date_deleted) { recent }
+
+      it 'keeps the referral and clears target_enrollment_id' do
+        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
+
+        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(source_enrollment.id)).to be true
+
+        ce_referral.reload
+        expect(ce_referral.target_enrollment_id).to be_nil
+        expect(ce_referral.source_enrollment_id).to eq(source_enrollment.id)
+      end
+    end
+
+    context 'when the referral is live and its target enrollment is purged' do
+      let(:referral_soft_deleted) { false }
+      let(:target_date_deleted) { old }
+      let(:source_date_deleted) { recent }
+
+      it 'keeps the referral and clears target_enrollment_id' do
+        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
+
+        ce_referral.reload
+        expect(ce_referral.deleted_at).to be_nil
+        expect(ce_referral.target_enrollment_id).to be_nil
+      end
+    end
+
+    context 'when the referral is itself soft-deleted past the retention date' do
+      let(:target_date_deleted) { old }
+      let(:source_date_deleted) { old }
+
+      before do
+        ce_referral.update_column(:deleted_at, old)
+        [referral_note, referral_participant].each { |record| record.update_column(:deleted_at, old) }
+      end
+
+      # run the real model list so its ordering (dependents before referral) is covered too
+      it 'purges the referral and its dependents' do
+        described_class.new.perform(retain_at: today - 1.year, dry_run: false)
+
+        expect(Hmis::Ce::Referral.with_deleted.exists?(ce_referral.id)).to be false
+        expect(Hmis::Ce::ReferralNote.with_deleted.exists?(referral_note.id)).to be false
+        expect(Hmis::Ce::ReferralParticipant.with_deleted.exists?(referral_participant.id)).to be false
+        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be false
+      end
+    end
+
+    context 'when only the source enrollment is purged' do
+      let(:target_date_deleted) { recent }
+      let(:source_date_deleted) { old }
+
+      it 'keeps the referral and clears source_enrollment_id' do
+        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
+
+        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be true
+
+        ce_referral.reload
+        expect(ce_referral.source_enrollment_id).to be_nil
+        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
+      end
+    end
+
+    context 'when neither enrollment is purged' do
+      let(:target_date_deleted) { recent }
+      let(:source_date_deleted) { recent }
+
+      it 'leaves the referral untouched' do
+        expect { run_purge }.not_to(change { GrdaWarehouse::Hud::Enrollment.with_deleted.count })
+
+        ce_referral.reload
+        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
+        expect(ce_referral.source_enrollment_id).to eq(source_enrollment.id)
+      end
+    end
+
+    context 'on a dry run' do
+      let(:target_date_deleted) { old }
+      let(:source_date_deleted) { recent }
+
+      it 'does not clear the reference' do
+        described_class.new.perform(
+          retain_at: today - 1.year,
+          models: [GrdaWarehouse::Hud::Enrollment],
+          dry_run: true,
+        )
+
+        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be true
+        ce_referral.reload
+        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
+      end
+    end
+  end
 end

--- a/spec/jobs/purge_soft_deleted_records_job_spec.rb
+++ b/spec/jobs/purge_soft_deleted_records_job_spec.rb
@@ -80,34 +80,33 @@ RSpec.describe PurgeSoftDeletedRecordsJob, type: :job do
     end
   end
 
-  describe '#perform on enrollments' do
+  describe '#perform on enrollments referenced by a CE referral' do
     let!(:ce_referral) { create(:hmis_ce_referral) }
-    let!(:referral_note) { create(:hmis_ce_referral_note, referral: ce_referral) }
-    let!(:referral_participant) { create(:hmis_ce_referral_participant, referral: ce_referral) }
 
     # the target enrollment must be in the referral's project, the source enrollment need not be
-    let(:target_enrollment) do
+    let!(:target_enrollment) do
       create(
         :hmis_hud_enrollment,
         data_source: ce_referral.data_source,
         project: ce_referral.target_project,
-        date_deleted: target_date_deleted,
+        date_deleted: today - 2.years,
       )
     end
-    let(:source_enrollment) do
-      create(:hmis_hud_enrollment, data_source: ce_referral.data_source, date_deleted: source_date_deleted)
+    let!(:source_enrollment) do
+      create(:hmis_hud_enrollment, data_source: ce_referral.data_source, date_deleted: today - 2.years)
+    end
+    let!(:unreferenced_enrollment) do
+      create(:hmis_hud_enrollment, data_source: ce_referral.data_source, date_deleted: today - 2.years)
     end
 
-    let(:old) { today - 2.years }
-    let(:recent) { today - 2.months }
+    # a referral that holds neither foreign key must not prevent unreferenced enrollments from being purged
+    let!(:referral_without_enrollments) { create(:hmis_ce_referral) }
 
-    # Enrollment declares dependent: :destroy only on the source side (has_many :outgoing_ce_referrals), so a
-    # referral pointing at a soft-deleted enrollment is frequently still live itself
-    let(:referral_soft_deleted) { true }
+    # a soft-deleted referral still holds the foreign keys
+    let(:referral_soft_deleted) { false }
 
     before do
       ce_referral.update!(target_enrollment: target_enrollment, source_enrollment: source_enrollment)
-      # a soft-deleted referral still holds the foreign key
       ce_referral.destroy! if referral_soft_deleted
     end
 
@@ -119,111 +118,27 @@ RSpec.describe PurgeSoftDeletedRecordsJob, type: :job do
       )
     end
 
-    context 'when both enrollments are purged' do
-      let(:target_date_deleted) { old }
-      let(:source_date_deleted) { old }
+    it 'skips referenced enrollments and purges the rest' do
+      expect(referral_without_enrollments.target_enrollment_id).to be_nil
+      expect(referral_without_enrollments.source_enrollment_id).to be_nil
 
-      it 'clears both references and leaves the referral to its own retention date' do
-        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-2)
+      run_purge
 
-        expect(Hmis::Ce::Referral.with_deleted.exists?(ce_referral.id)).to be true
-        ce_referral.reload
-        expect(ce_referral.target_enrollment_id).to be_nil
-        expect(ce_referral.source_enrollment_id).to be_nil
-      end
+      with_deleted = GrdaWarehouse::Hud::Enrollment.with_deleted
+      expect(with_deleted.exists?(target_enrollment.id)).to be true
+      expect(with_deleted.exists?(source_enrollment.id)).to be true
+      expect(with_deleted.exists?(unreferenced_enrollment.id)).to be false
     end
 
-    context 'when only the target enrollment is purged' do
-      let(:target_date_deleted) { old }
-      let(:source_date_deleted) { recent }
+    context 'when the referral is soft-deleted' do
+      let(:referral_soft_deleted) { true }
 
-      it 'keeps the referral and clears target_enrollment_id' do
-        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
+      it 'still skips referenced enrollments' do
+        run_purge
 
-        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(source_enrollment.id)).to be true
-
-        ce_referral.reload
-        expect(ce_referral.target_enrollment_id).to be_nil
-        expect(ce_referral.source_enrollment_id).to eq(source_enrollment.id)
-      end
-    end
-
-    context 'when the referral is live and its target enrollment is purged' do
-      let(:referral_soft_deleted) { false }
-      let(:target_date_deleted) { old }
-      let(:source_date_deleted) { recent }
-
-      it 'keeps the referral and clears target_enrollment_id' do
-        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
-
-        ce_referral.reload
-        expect(ce_referral.deleted_at).to be_nil
-        expect(ce_referral.target_enrollment_id).to be_nil
-      end
-    end
-
-    context 'when the referral is itself soft-deleted past the retention date' do
-      let(:target_date_deleted) { old }
-      let(:source_date_deleted) { old }
-
-      before do
-        ce_referral.update_column(:deleted_at, old)
-        [referral_note, referral_participant].each { |record| record.update_column(:deleted_at, old) }
-      end
-
-      # run the real model list so its ordering (dependents before referral) is covered too
-      it 'purges the referral and its dependents' do
-        described_class.new.perform(retain_at: today - 1.year, dry_run: false)
-
-        expect(Hmis::Ce::Referral.with_deleted.exists?(ce_referral.id)).to be false
-        expect(Hmis::Ce::ReferralNote.with_deleted.exists?(referral_note.id)).to be false
-        expect(Hmis::Ce::ReferralParticipant.with_deleted.exists?(referral_participant.id)).to be false
-        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be false
-      end
-    end
-
-    context 'when only the source enrollment is purged' do
-      let(:target_date_deleted) { recent }
-      let(:source_date_deleted) { old }
-
-      it 'keeps the referral and clears source_enrollment_id' do
-        expect { run_purge }.to change { GrdaWarehouse::Hud::Enrollment.with_deleted.count }.by(-1)
-
-        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be true
-
-        ce_referral.reload
-        expect(ce_referral.source_enrollment_id).to be_nil
-        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
-      end
-    end
-
-    context 'when neither enrollment is purged' do
-      let(:target_date_deleted) { recent }
-      let(:source_date_deleted) { recent }
-
-      it 'leaves the referral untouched' do
-        expect { run_purge }.not_to(change { GrdaWarehouse::Hud::Enrollment.with_deleted.count })
-
-        ce_referral.reload
-        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
-        expect(ce_referral.source_enrollment_id).to eq(source_enrollment.id)
-      end
-    end
-
-    context 'on a dry run' do
-      let(:target_date_deleted) { old }
-      let(:source_date_deleted) { recent }
-
-      it 'does not clear the reference' do
-        described_class.new.perform(
-          retain_at: today - 1.year,
-          models: [GrdaWarehouse::Hud::Enrollment],
-          dry_run: true,
-        )
-
-        expect(GrdaWarehouse::Hud::Enrollment.with_deleted.exists?(target_enrollment.id)).to be true
-        ce_referral.reload
-        expect(ce_referral.target_enrollment_id).to eq(target_enrollment.id)
+        with_deleted = GrdaWarehouse::Hud::Enrollment.with_deleted
+        expect(with_deleted.exists?(target_enrollment.id)).to be true
+        expect(with_deleted.exists?(source_enrollment.id)).to be true
       end
     end
   end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
Deleting an enrollment that a CE referral still points at raised a FK error. Filter those enrollments out of the purge instead, including ones referenced by soft-deleted referrals. Left a note that nothing purges CE referrals yet, so those enrollments are retained indefinitely.

## Type of change
Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

