### PR TITLE
[#8424] Demote impossible DOBs when reconciling warehouse client records

### DIFF
--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -333,6 +333,7 @@ module GrdaWarehouse
         :enable_external_data_sharing_exclusion,
         :rds_s3_integration_role_arn,
         :relevant_state_codes,
+        :dob_dq_demotion_enabled,
         client_details: [],
         client_demographic_columns: [],
       ]

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -159,6 +159,14 @@ module GrdaWarehouse
       }
     end
 
+    def self.available_dob_selection_methods
+      {
+        'Use the oldest record, and trust the date of birth it reports' => :legacy,
+        'Use the oldest record, but demote impossible dates' => :demote_oldest,
+        'Use the newest record, but demote impossible dates' => :demote_newest,
+      }
+    end
+
     def self.available_cas_calculators
       {
         'Boston Pathways' => 'GrdaWarehouse::CasProjectClientCalculator::Boston',
@@ -333,7 +341,7 @@ module GrdaWarehouse
         :enable_external_data_sharing_exclusion,
         :rds_s3_integration_role_arn,
         :relevant_state_codes,
-        :dob_dq_demotion_enabled,
+        :dob_selection_method,
         client_details: [],
         client_demographic_columns: [],
       ]

--- a/app/models/grda_warehouse/config.rb
+++ b/app/models/grda_warehouse/config.rb
@@ -162,8 +162,8 @@ module GrdaWarehouse
     def self.available_dob_selection_methods
       {
         'Use the oldest record, and trust the date of birth it reports' => :legacy,
-        'Use the oldest record, but demote impossible dates' => :demote_oldest,
-        'Use the newest record, but demote impossible dates' => :demote_newest,
+        'Use the oldest record, but demote impossible dates' => :oldest,
+        'Use the newest record, but demote impossible dates' => :newest,
       }
     end
 

--- a/app/models/grda_warehouse/dob_selector.rb
+++ b/app/models/grda_warehouse/dob_selector.rb
@@ -1,0 +1,155 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+module GrdaWarehouse
+  # Determines the preferred DOB and DOB data quality from a set of source
+  # client records. Parallels GrdaWarehouse::SSNSelector, but judges validity by
+  # comparing the DOB against the source record's own DateCreated rather than by
+  # inspecting the value's shape.
+  #
+  # Candidates are ranked on, in order:
+  #   1. DOBDataQuality (lower is better)
+  #   2. Validity (a possible DOB beats an impossible one at the same quality)
+  #   3. Record timestamp (DateCreated), configurable to prefer oldest or newest
+  #   4. Record ID (lower is better)
+  #
+  # A DOB is impossible when it falls after its record's DateCreated, or more
+  # than MAX_AGE_IN_YEARS before it. An impossible DOB reported as full or
+  # approximate is demoted to approximate; the value itself is always kept so a
+  # mistyped date is not silently discarded.
+  class DOBSelector
+    MAX_AGE_IN_YEARS = 150
+
+    Candidate = Struct.new(:value, :quality, :tie_breakers, keyword_init: true)
+
+    def self.call(dest_attr:, source_clients:, use_oldest: true)
+      new(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest).call
+    end
+
+    def initialize(dest_attr:, source_clients:, use_oldest: true)
+      @dest_attr = dest_attr.with_indifferent_access
+      @source_clients = Array.wrap(source_clients).map { |client| normalize_source(client) }
+      @use_oldest = use_oldest
+    end
+
+    def call
+      best = select_best_candidate
+      if best
+        @dest_attr[:DOB] = best.value
+        @dest_attr[:DOBDataQuality] = best.quality
+      else
+        @dest_attr[:DOB] = nil
+        @dest_attr[:DOBDataQuality] = 99
+      end
+      @dest_attr
+    end
+
+    private
+
+    def select_best_candidate
+      @source_clients.
+        filter_map { |source| build_candidate_from_source(source) }.
+        min_by(&:tie_breakers)
+    end
+
+    def build_candidate_from_source(source)
+      value = source[:DOB]
+      value = value.strip if value.is_a?(String)
+      return if value.blank?
+
+      initial_dq = coerce_dq(source[:DOBDataQuality])
+      dq = initial_dq
+      dq = 99 unless dq&.in?(dob_dqs)
+
+      created_at = created_time_for(source[:DateCreated])
+      invalid = invalid_dob?(value, created_at || Time.current)
+      dq = 2 if invalid && dq.in?([1, 2])
+
+      tie_breakers = [
+        dq,
+        invalid ? 1 : 0,
+        date_key_for(created_at),
+        source_identifier_for(source),
+      ]
+
+      Candidate.new(value: value, quality: dq, tie_breakers: tie_breakers)
+    end
+
+    def invalid_dob?(value, reference)
+      dob = value.to_date
+      reference_date = reference.to_date
+
+      dob > reference_date || dob < reference_date - MAX_AGE_IN_YEARS.years
+    end
+
+    def normalize_source(client)
+      base =
+        case client
+        when ActiveSupport::HashWithIndifferentAccess
+          client
+        when Hash
+          client.with_indifferent_access
+        when ActiveRecord::Base
+          client.attributes.with_indifferent_access
+        else
+          raise ArgumentError, "Unsupported source client: #{client.class.name}"
+        end
+
+      base[:DOBDataQuality] = base[:DOBDataQuality].presence || 99
+      base
+    end
+
+    def created_time_for(value)
+      case value
+      when nil, ''
+        nil
+      when Time, DateTime, ActiveSupport::TimeWithZone
+        value
+      when Date
+        value.to_time
+      else
+        raise ArgumentError, "invalid timestamp #{value.inspect}"
+      end
+    end
+
+    def date_key_for(created_at)
+      timestamp = created_at&.to_i
+      timestamp ||= default_date_key
+      timestamp *= -1 unless use_oldest?
+      timestamp
+    end
+
+    def use_oldest?
+      @use_oldest
+    end
+
+    def default_date_key
+      use_oldest? ? Float::INFINITY : -Float::INFINITY
+    end
+
+    def source_identifier_for(source)
+      raw = source[:id]
+      return Float::INFINITY if raw.blank?
+
+      coerced = Integer(raw, exception: false)
+      coerced || Float::INFINITY
+    end
+
+    def dob_dqs
+      @dob_dqs ||= HudHelper.util.dob_data_quality_options.keys.sort
+    end
+
+    def coerce_dq(value)
+      return if value.blank?
+
+      return value if value.is_a?(Integer)
+
+      Integer(value, exception: false)
+    end
+  end
+end

--- a/app/models/grda_warehouse/dob_selector.rb
+++ b/app/models/grda_warehouse/dob_selector.rb
@@ -117,19 +117,22 @@ module GrdaWarehouse
       end
     end
 
+    # min_by picks the lowest key, so the direction is expressed in the sign:
+    #   use_oldest  - the earliest timestamp is already the lowest, leave it be.
+    #   otherwise   - negate, which makes the latest timestamp the lowest.
+    # Infinity is returned before the negation and sits above every real key
+    # either way, so a record with no DateCreated always loses this rank rather
+    # than winning it.
     def date_key_for(created_at)
-      timestamp = created_at&.to_i
-      timestamp ||= default_date_key
+      return Float::INFINITY if created_at.nil?
+
+      timestamp = created_at.to_i
       timestamp *= -1 unless use_oldest?
       timestamp
     end
 
     def use_oldest?
       @use_oldest
-    end
-
-    def default_date_key
-      use_oldest? ? Float::INFINITY : -Float::INFINITY
     end
 
     def source_identifier_for(source)

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -522,6 +522,12 @@ module GrdaWarehouse::Tasks
     end
 
     def choose_best_dob dest_attr, source_clients
+      return choose_best_dob_legacy(dest_attr, source_clients) unless GrdaWarehouse::Config.get(:dob_dq_demotion_enabled)
+
+      GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: true)
+    end
+
+    def choose_best_dob_legacy dest_attr, source_clients
       # Get the best DOB (has value and quality is full or partial, oldest breaks the tie)
       non_blank_dob = source_clients.select { |sc| sc[:DOB].present? }
       if non_blank_dob.any?

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -522,9 +522,14 @@ module GrdaWarehouse::Tasks
     end
 
     def choose_best_dob dest_attr, source_clients
-      return choose_best_dob_legacy(dest_attr, source_clients) unless GrdaWarehouse::Config.get(:dob_dq_demotion_enabled)
-
-      GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: true)
+      case GrdaWarehouse::Config.get(:dob_selection_method).to_s
+      when 'demote_oldest'
+        GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: true)
+      when 'demote_newest'
+        GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: false)
+      else
+        choose_best_dob_legacy(dest_attr, source_clients)
+      end
     end
 
     def choose_best_dob_legacy dest_attr, source_clients

--- a/app/models/grda_warehouse/tasks/client_cleanup.rb
+++ b/app/models/grda_warehouse/tasks/client_cleanup.rb
@@ -523,9 +523,9 @@ module GrdaWarehouse::Tasks
 
     def choose_best_dob dest_attr, source_clients
       case GrdaWarehouse::Config.get(:dob_selection_method).to_s
-      when 'demote_oldest'
+      when 'oldest'
         GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: true)
-      when 'demote_newest'
+      when 'newest'
         GrdaWarehouse::DOBSelector.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: false)
       else
         choose_best_dob_legacy(dest_attr, source_clients)

--- a/app/views/admin/configs/_client_calculations.haml
+++ b/app/views/admin/configs/_client_calculations.haml
@@ -15,4 +15,5 @@
     = f.input :enable_youth_hrp, label: 'Enable Youth Housing Resolution Plans'
     = f.input :enable_youth_unstably_housed, label: 'Enable youth Unstably Housed option'
     = f.input :warehouse_client_name_order, label: 'How should the names on clients be calculated?', collection: GrdaWarehouse::Config.available_warehouse_client_name_orders, as: :select_two
+    = f.input :dob_dq_demotion_enabled, label: 'Should impossible dates of birth be demoted when calculating client DOB?', hint: 'When enabled, a DOB that postdates its own record, or precedes it by more than 150 years, is treated as approximate rather than full.'
     = f.input :supplemental_enrollment_importer, label: 'What version of the supplemental enrollment importer should we use.', collection: GrdaWarehouse::Config.available_supplemental_enrollment_importers, as: :select_two

--- a/app/views/admin/configs/_client_calculations.haml
+++ b/app/views/admin/configs/_client_calculations.haml
@@ -15,5 +15,5 @@
     = f.input :enable_youth_hrp, label: 'Enable Youth Housing Resolution Plans'
     = f.input :enable_youth_unstably_housed, label: 'Enable youth Unstably Housed option'
     = f.input :warehouse_client_name_order, label: 'How should the names on clients be calculated?', collection: GrdaWarehouse::Config.available_warehouse_client_name_orders, as: :select_two
-    = f.input :dob_dq_demotion_enabled, label: 'Should impossible dates of birth be demoted when calculating client DOB?', hint: 'When enabled, a DOB that postdates its own record, or precedes it by more than 150 years, is treated as approximate rather than full.'
+    = f.input :dob_selection_method, label: 'How should the client DOBs be calculated?', hint: 'An impossible DOB is one that postdates the record reporting it, or precedes it by more than 150 years. Demoting marks it approximate rather than full, so a possible date from another record can be used instead.', collection: GrdaWarehouse::Config.available_dob_selection_methods, as: :select_two
     = f.input :supplemental_enrollment_importer, label: 'What version of the supplemental enrollment importer should we use.', collection: GrdaWarehouse::Config.available_supplemental_enrollment_importers, as: :select_two

--- a/db/warehouse/migrate/20260831120000_add_dob_dq_demotion_enabled_to_configs.rb
+++ b/db/warehouse/migrate/20260831120000_add_dob_dq_demotion_enabled_to_configs.rb
@@ -1,0 +1,13 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddDOBDqDemotionEnabledToConfigs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :configs, :dob_dq_demotion_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/warehouse/migrate/20260831120000_add_dob_selection_method_to_configs.rb
+++ b/db/warehouse/migrate/20260831120000_add_dob_selection_method_to_configs.rb
@@ -6,8 +6,8 @@
 
 # frozen_string_literal: true
 
-class AddDOBDqDemotionEnabledToConfigs < ActiveRecord::Migration[8.1]
+class AddDOBSelectionMethodToConfigs < ActiveRecord::Migration[8.1]
   def change
-    add_column :configs, :dob_dq_demotion_enabled, :boolean, default: false, null: false
+    add_column :configs, :dob_selection_method, :string, default: 'legacy', null: false
   end
 end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -27100,7 +27100,8 @@ CREATE TABLE public.configs (
     enable_external_data_sharing_exclusion boolean DEFAULT false NOT NULL,
     client_demographic_columns jsonb,
     created_at timestamp(6) without time zone,
-    updated_at timestamp(6) without time zone
+    updated_at timestamp(6) without time zone,
+    dob_dq_demotion_enabled boolean DEFAULT false NOT NULL
 );
 
 
@@ -359988,6 +359989,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260831120000'),
 ('20260819120200'),
 ('20260819120000'),
 ('20260818130528'),

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -27101,7 +27101,7 @@ CREATE TABLE public.configs (
     client_demographic_columns jsonb,
     created_at timestamp(6) without time zone,
     updated_at timestamp(6) without time zone,
-    dob_dq_demotion_enabled boolean DEFAULT false NOT NULL
+    dob_selection_method character varying DEFAULT 'legacy'::character varying NOT NULL
 );
 
 

--- a/spec/models/grda_warehouse/config_spec.rb
+++ b/spec/models/grda_warehouse/config_spec.rb
@@ -26,6 +26,17 @@ RSpec.describe GrdaWarehouse::Config, type: :model do
     end
   end
 
+  describe 'dob_dq_demotion_enabled' do
+    it 'is a known config so it can be set from the admin form' do
+      expect(described_class.known_configs).to include(:dob_dq_demotion_enabled)
+    end
+
+    it 'defaults to off, preserving the legacy DOB selection' do
+      config = create(:config)
+      expect(config.dob_dq_demotion_enabled).to be(false)
+    end
+  end
+
   describe 'PaperTrail' do
     it 'creates a version on update' do
       PaperTrailHelper.with_paper_trail do

--- a/spec/models/grda_warehouse/config_spec.rb
+++ b/spec/models/grda_warehouse/config_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe GrdaWarehouse::Config, type: :model do
 
     it 'offers a legacy option plus one per sort direction' do
       expect(described_class.available_dob_selection_methods.values).
-        to contain_exactly(:legacy, :demote_oldest, :demote_newest)
+        to contain_exactly(:legacy, :oldest, :newest)
     end
   end
 

--- a/spec/models/grda_warehouse/config_spec.rb
+++ b/spec/models/grda_warehouse/config_spec.rb
@@ -26,14 +26,19 @@ RSpec.describe GrdaWarehouse::Config, type: :model do
     end
   end
 
-  describe 'dob_dq_demotion_enabled' do
+  describe 'dob_selection_method' do
     it 'is a known config so it can be set from the admin form' do
-      expect(described_class.known_configs).to include(:dob_dq_demotion_enabled)
+      expect(described_class.known_configs).to include(:dob_selection_method)
     end
 
-    it 'defaults to off, preserving the legacy DOB selection' do
+    it 'defaults to legacy, preserving the previous DOB selection' do
       config = create(:config)
-      expect(config.dob_dq_demotion_enabled).to be(false)
+      expect(config.dob_selection_method).to eq('legacy')
+    end
+
+    it 'offers a legacy option plus one per sort direction' do
+      expect(described_class.available_dob_selection_methods.values).
+        to contain_exactly(:legacy, :demote_oldest, :demote_newest)
     end
   end
 

--- a/spec/models/grda_warehouse/dob_selector_spec.rb
+++ b/spec/models/grda_warehouse/dob_selector_spec.rb
@@ -1,0 +1,447 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::DOBSelector do
+  subject(:selected) do
+    described_class.call(dest_attr: dest_attr, source_clients: source_clients, use_oldest: use_oldest)
+  end
+
+  let(:dest_attr) { {} }
+  let(:source_clients) { [] }
+  let(:use_oldest) { true }
+  # object_double, not instance_double: HudHelper.util returns a module.
+  let(:hud_util) { object_double(HudUtility2026) }
+
+  # Every case states its reference date explicitly. Validity is judged against
+  # DateCreated, never against the suite clock.
+  let(:reference) { Time.zone.local(2023, 1, 1) }
+  let(:plausible_dob) { Date.new(2003, 1, 1) } # 20 years before reference
+  let(:future_dob) { Date.new(2023, 6, 1) } # after reference
+  let(:exactly_150_dob) { Date.new(1873, 1, 1) } # exactly 150 years before reference
+  let(:too_old_dob) { Date.new(1872, 12, 31) } # 150 years and 1 day before reference
+
+  before do
+    allow(hud_util).to receive(:dob_data_quality_options).
+      and_return(
+        {
+          1 => 'Full DOB reported',
+          2 => 'Approximate or partial DOB reported',
+          8 => "Client doesn't know",
+          9 => 'Client prefers not to answer',
+          99 => 'Data not collected',
+        },
+      )
+    allow(HudHelper).to receive(:util).and_return(hud_util)
+  end
+
+  describe '.call' do
+    describe 'validity and demotion' do
+      context 'when a DQ 1 DOB precedes DateCreated by a plausible span' do
+        let(:source_clients) do
+          [{ DOB: plausible_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'keeps the full data quality and the value' do
+          expect(selected[:DOB]).to eq(plausible_dob)
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when a DQ 1 DOB falls after DateCreated' do
+        let(:source_clients) do
+          [{ DOB: future_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'demotes to approximate and keeps the value' do
+          expect(selected[:DOB]).to eq(future_dob)
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when a DQ 1 DOB is 150 years and one day before DateCreated' do
+        let(:source_clients) do
+          [{ DOB: too_old_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'demotes to approximate and keeps the value' do
+          expect(selected[:DOB]).to eq(too_old_dob)
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when a DQ 1 DOB is exactly 150 years before DateCreated' do
+        let(:source_clients) do
+          [{ DOB: exactly_150_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'treats the boundary as valid and keeps the full data quality' do
+          expect(selected[:DOB]).to eq(exactly_150_dob)
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when a DQ 2 DOB is invalid' do
+        let(:source_clients) do
+          [{ DOB: future_dob, DOBDataQuality: 2, DateCreated: reference, id: 1 }]
+        end
+
+        it 'neither double-demotes nor promotes' do
+          expect(selected[:DOB]).to eq(future_dob)
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      [8, 9, 99].each do |dq|
+        context "when a DQ #{dq} DOB is invalid" do
+          let(:source_clients) do
+            [{ DOB: future_dob, DOBDataQuality: dq, DateCreated: reference, id: 1 }]
+          end
+
+          it 'leaves the data quality unchanged' do
+            expect(selected[:DOB]).to eq(future_dob)
+            expect(selected[:DOBDataQuality]).to eq(dq)
+          end
+        end
+      end
+
+      context 'when the only source has a nil DOB' do
+        let(:source_clients) do
+          [{ DOB: nil, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'drops the candidate' do
+          expect(selected[:DOB]).to be_nil
+          expect(selected[:DOBDataQuality]).to eq(99)
+        end
+      end
+
+      context 'when the only source has a blank DOB' do
+        let(:source_clients) do
+          [{ DOB: '', DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'drops the candidate' do
+          expect(selected[:DOB]).to be_nil
+          expect(selected[:DOBDataQuality]).to eq(99)
+        end
+      end
+
+      [3, '', nil].each do |dq|
+        context "when the data quality is #{dq.inspect}, outside the HUD list" do
+          let(:source_clients) do
+            [{ DOB: plausible_dob, DOBDataQuality: dq, DateCreated: reference, id: 1 }]
+          end
+
+          it 'reports data not collected and keeps the value' do
+            expect(selected[:DOB]).to eq(plausible_dob)
+            expect(selected[:DOBDataQuality]).to eq(99)
+          end
+        end
+      end
+
+      context 'when the data quality arrives as the string 1' do
+        let(:source_clients) do
+          [{ DOB: future_dob, DOBDataQuality: '1', DateCreated: reference, id: 1 }]
+        end
+
+        it 'coerces it and applies the DQ 1 demotion' do
+          expect(selected[:DOB]).to eq(future_dob)
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when the DOB arrives as a String' do
+        let(:source_clients) do
+          [{ DOB: '2003-01-01', DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'accepts it and judges validity the same way' do
+          expect(selected[:DOB]).to eq('2003-01-01')
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when a String DOB is invalid' do
+        let(:source_clients) do
+          [{ DOB: '2023-06-01', DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'demotes it just as it would a Date' do
+          expect(selected[:DOB]).to eq('2023-06-01')
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when DateCreated is absent' do
+        around { |example| travel_to(Time.zone.local(2023, 1, 1)) { example.run } }
+
+        context 'and the DOB is in the future relative to now' do
+          let(:source_clients) do
+            [{ DOB: Date.new(2024, 1, 1), DOBDataQuality: 1, DateCreated: nil, id: 1 }]
+          end
+
+          it 'falls back to the current time and demotes' do
+            expect(selected[:DOB]).to eq(Date.new(2024, 1, 1))
+            expect(selected[:DOBDataQuality]).to eq(2)
+          end
+        end
+
+        context 'and the DOB is plausible relative to now' do
+          let(:source_clients) do
+            [{ DOB: plausible_dob, DOBDataQuality: 1, DateCreated: nil, id: 1 }]
+          end
+
+          it 'keeps the full data quality' do
+            expect(selected[:DOB]).to eq(plausible_dob)
+            expect(selected[:DOBDataQuality]).to eq(1)
+          end
+        end
+      end
+    end
+
+    describe 'selection and tie-breaking' do
+      context 'when no source client has a DOB' do
+        it 'returns a blank DOB with unknown quality' do
+          expect(selected[:DOB]).to be_nil
+          expect(selected[:DOBDataQuality]).to eq(99)
+        end
+      end
+
+      context 'when an older DQ 1 record has an impossible DOB (the QA scenario)' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            { DOB: Date.new(2002, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'prefers the newer record whose DOB is possible' do
+          expect(selected[:DOB]).to eq(Date.new(2002, 1, 1))
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when a valid DQ 1 competes with a valid DQ 2' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 2, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            { DOB: plausible_dob, DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'prefers the higher quality regardless of dates' do
+          expect(selected[:DOB]).to eq(plausible_dob)
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when a demoted invalid DOB is older than a genuinely approximate one' do
+        let(:source_clients) do
+          [
+            # DQ 1 but impossible, so demoted to 2. Older DateCreated.
+            { DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            # Genuinely approximate and possible. Newer DateCreated.
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 2, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'ranks validity ahead of age at equal data quality' do
+          expect(selected[:DOB]).to eq(Date.new(1990, 1, 1))
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when two valid DQ 1 records differ only by DateCreated' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(1980, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'selects the oldest record' do
+          expect(selected[:DOB]).to eq(Date.new(1980, 1, 1))
+        end
+
+        context 'when configured to prefer the newest' do
+          let(:use_oldest) { false }
+
+          it 'selects the newest record' do
+            expect(selected[:DOB]).to eq(Date.new(1990, 1, 1))
+          end
+        end
+      end
+
+      context 'when one of two equal records has no DateCreated' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(1980, 1, 1), DOBDataQuality: 1, DateCreated: nil, id: 1 },
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'prefers the timestamped record' do
+          expect(selected[:DOB]).to eq(Date.new(1990, 1, 1))
+        end
+
+        context 'when configured to prefer the newest' do
+          let(:use_oldest) { false }
+
+          it 'still prefers the timestamped record' do
+            expect(selected[:DOB]).to eq(Date.new(1990, 1, 1))
+          end
+        end
+      end
+
+      context 'when quality, validity, and DateCreated all tie' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 7 },
+            { DOB: Date.new(1980, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 3 },
+          ]
+        end
+
+        it 'selects the lowest id' do
+          expect(selected[:DOB]).to eq(Date.new(1980, 1, 1))
+        end
+      end
+
+      context 'when an otherwise tied record has no id' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: nil },
+            { DOB: Date.new(1980, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 3 },
+          ]
+        end
+
+        it 'prefers the record with a real id' do
+          expect(selected[:DOB]).to eq(Date.new(1980, 1, 1))
+        end
+      end
+
+      context 'when every candidate starts at DQ 1 with an impossible DOB' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            { DOB: Date.new(2023, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'still selects the best of them, demoted, with the value kept' do
+          expect(selected[:DOB]).to eq(Date.new(2022, 6, 1))
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when every candidate starts at DQ 99 with an impossible DOB' do
+        let(:source_clients) do
+          [
+            { DOB: Date.new(2022, 6, 1), DOBDataQuality: 99, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+            { DOB: Date.new(2023, 6, 1), DOBDataQuality: 99, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+          ]
+        end
+
+        it 'selects the best of them with nothing to demote' do
+          expect(selected[:DOB]).to eq(Date.new(2022, 6, 1))
+          expect(selected[:DOBDataQuality]).to eq(99)
+        end
+      end
+
+      context 'when no source has a DOB but the destination already had one' do
+        let(:dest_attr) { { DOB: Date.new(1975, 5, 5), DOBDataQuality: 1 } }
+        let(:source_clients) do
+          [{ DOB: nil, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'clears the destination DOB and reports data not collected' do
+          expect(selected[:DOB]).to be_nil
+          expect(selected[:DOBDataQuality]).to eq(99)
+        end
+      end
+    end
+
+    describe 'source normalization' do
+      context 'when a source client is an unsupported class' do
+        let(:source_clients) { ['not a client'] }
+
+        it 'raises ArgumentError' do
+          expect { selected }.to raise_error(ArgumentError, /Unsupported source client/)
+        end
+      end
+
+      context 'when a source client is an ActiveRecord client, as in production' do
+        let(:source_clients) do
+          [
+            GrdaWarehouse::Hud::Client.new(
+              DOB: Date.new(2022, 6, 1),
+              DOBDataQuality: 1,
+              DateCreated: Time.zone.local(2021, 1, 1),
+            ),
+            GrdaWarehouse::Hud::Client.new(
+              DOB: Date.new(2002, 1, 1),
+              DOBDataQuality: 1,
+              DateCreated: Time.zone.local(2022, 1, 1),
+            ),
+          ]
+        end
+
+        it 'reads the HUD attributes off the record and demotes the impossible DOB' do
+          expect(selected[:DOB]).to eq(Date.new(2002, 1, 1))
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+
+      context 'when DateCreated is a Date rather than a Time' do
+        let(:source_clients) do
+          [{ DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Date.new(2021, 1, 1), id: 1 }]
+        end
+
+        it 'accepts it as the reference date' do
+          expect(selected[:DOB]).to eq(Date.new(2022, 6, 1))
+          expect(selected[:DOBDataQuality]).to eq(2)
+        end
+      end
+
+      context 'when DateCreated is a type that cannot be a timestamp' do
+        let(:source_clients) do
+          [{ DOB: plausible_dob, DOBDataQuality: 1, DateCreated: 'not a date', id: 1 }]
+        end
+
+        it 'raises ArgumentError rather than guessing' do
+          expect { selected }.to raise_error(ArgumentError, /invalid timestamp/)
+        end
+      end
+
+      context 'when the destination carries attributes this selector does not own' do
+        let(:dest_attr) { { FirstName: 'Blair', SSN: '555555555', DOB: nil, DOBDataQuality: nil } }
+        let(:source_clients) do
+          [{ DOB: plausible_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }]
+        end
+
+        it 'returns them untouched alongside the chosen DOB' do
+          expect(selected[:FirstName]).to eq('Blair')
+          expect(selected[:SSN]).to eq('555555555')
+          expect(selected[:DOB]).to eq(plausible_dob)
+        end
+      end
+
+      context 'when a source client is a HashWithIndifferentAccess' do
+        let(:source_clients) do
+          [{ DOB: plausible_dob, DOBDataQuality: 1, DateCreated: reference, id: 1 }.with_indifferent_access]
+        end
+
+        it 'is accepted' do
+          expect(selected[:DOB]).to eq(plausible_dob)
+          expect(selected[:DOBDataQuality]).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -635,6 +635,108 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       end
     end
   end
+
+  describe 'choose_best_dob method' do
+    let(:cleanup) { GrdaWarehouse::Tasks::ClientCleanup.new }
+    let(:dest_attr) { { DOB: nil, DOBDataQuality: nil } }
+    let(:flag) { false }
+
+    before do
+      allow(GrdaWarehouse::Config).to receive(:get).and_call_original
+      allow(GrdaWarehouse::Config).to receive(:get).with(:dob_dq_demotion_enabled).and_return(flag)
+    end
+
+    # Source A's DOB postdates its own DateCreated, so it is impossible. It is
+    # nonetheless the older record.
+    let(:qa_source_clients) do
+      [
+        { DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+        { DOB: Date.new(2002, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+      ]
+    end
+
+    context 'when dob_dq_demotion_enabled is off' do
+      let(:flag) { false }
+
+      it 'pins the legacy outcome: the older record wins even with an impossible DOB' do
+        result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(2022, 6, 1))
+        expect(result[:DOBDataQuality]).to eq(1)
+      end
+
+      it 'prefers the better data quality over the older record' do
+        source_clients = [
+          { DOB: Date.new(1990, 1, 1), DOBDataQuality: 2, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+          { DOB: Date.new(1991, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(1991, 1, 1))
+        expect(result[:DOBDataQuality]).to eq(1)
+      end
+
+      it 'breaks a data quality tie on the oldest DateCreated' do
+        source_clients = [
+          { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 1 },
+          { DOB: Date.new(1991, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 2 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(1991, 1, 1))
+      end
+
+      it 'clears an existing destination DOB when no source has one' do
+        dest_attr = { DOB: Date.new(1975, 5, 5), DOBDataQuality: 1 }
+        source_clients = [
+          { DOB: nil, DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to be_nil
+        expect(result[:DOBDataQuality]).to eq(99)
+      end
+
+      it 'does not delegate to DOBSelector' do
+        expect(GrdaWarehouse::DOBSelector).not_to receive(:call)
+
+        cleanup.choose_best_dob(dest_attr, qa_source_clients)
+      end
+    end
+
+    context 'when dob_dq_demotion_enabled is on' do
+      let(:flag) { true }
+
+      it 'prefers the newer record whose DOB is possible' do
+        result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(2002, 1, 1))
+        expect(result[:DOBDataQuality]).to eq(1)
+      end
+
+      it 'exposes the demotion when every candidate has an impossible DOB' do
+        source_clients = [
+          { DOB: Date.new(2022, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(2022, 6, 1))
+        expect(result[:DOBDataQuality]).to eq(2)
+      end
+
+      it 'delegates to DOBSelector, preferring the oldest record' do
+        expect(GrdaWarehouse::DOBSelector).to receive(:call).
+          with(dest_attr: dest_attr, source_clients: qa_source_clients, use_oldest: true).
+          and_call_original
+
+        cleanup.choose_best_dob(dest_attr, qa_source_clients)
+      end
+    end
+  end
   describe 'When Updating destination records from client sources' do
     let!(:destination_client) { create(:grda_warehouse_hud_client) }
     let!(:source_1) { create(:grda_warehouse_hud_client) }

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -639,11 +639,11 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
   describe 'choose_best_dob method' do
     let(:cleanup) { GrdaWarehouse::Tasks::ClientCleanup.new }
     let(:dest_attr) { { DOB: nil, DOBDataQuality: nil } }
-    let(:flag) { false }
+    let(:selection_method) { :legacy }
 
     before do
       allow(GrdaWarehouse::Config).to receive(:get).and_call_original
-      allow(GrdaWarehouse::Config).to receive(:get).with(:dob_dq_demotion_enabled).and_return(flag)
+      allow(GrdaWarehouse::Config).to receive(:get).with(:dob_selection_method).and_return(selection_method)
     end
 
     # Source A's DOB postdates its own DateCreated, so it is impossible. It is
@@ -655,8 +655,8 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       ]
     end
 
-    context 'when dob_dq_demotion_enabled is off' do
-      let(:flag) { false }
+    context 'when dob_selection_method is legacy' do
+      let(:selection_method) { :legacy }
 
       it 'pins the legacy outcome: the older record wins even with an impossible DOB' do
         result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
@@ -707,8 +707,8 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       end
     end
 
-    context 'when dob_dq_demotion_enabled is on' do
-      let(:flag) { true }
+    context 'when dob_selection_method is demote_oldest' do
+      let(:selection_method) { :demote_oldest }
 
       it 'prefers the newer record whose DOB is possible' do
         result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
@@ -734,6 +734,51 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
           and_call_original
 
         cleanup.choose_best_dob(dest_attr, qa_source_clients)
+      end
+    end
+
+    context 'when dob_selection_method is demote_newest' do
+      let(:selection_method) { :demote_newest }
+
+      it 'delegates to DOBSelector, preferring the newest record' do
+        expect(GrdaWarehouse::DOBSelector).to receive(:call).
+          with(dest_attr: dest_attr, source_clients: qa_source_clients, use_oldest: false).
+          and_call_original
+
+        cleanup.choose_best_dob(dest_attr, qa_source_clients)
+      end
+
+      it 'breaks a tie on the newest record rather than the oldest' do
+        source_clients = [
+          { DOB: Date.new(1980, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2021, 1, 1), id: 1 },
+          { DOB: Date.new(1990, 1, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 2 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(1990, 1, 1))
+      end
+
+      it 'still demotes an impossible DOB' do
+        source_clients = [
+          { DOB: Date.new(2023, 6, 1), DOBDataQuality: 1, DateCreated: Time.zone.local(2022, 1, 1), id: 1 },
+        ]
+
+        result = cleanup.choose_best_dob(dest_attr, source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(2023, 6, 1))
+        expect(result[:DOBDataQuality]).to eq(2)
+      end
+    end
+
+    context 'when dob_selection_method holds an unrecognized value' do
+      let(:selection_method) { 'something_else' }
+
+      it 'falls back to the legacy selection rather than demoting' do
+        result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
+
+        expect(result[:DOB]).to eq(Date.new(2022, 6, 1))
+        expect(result[:DOBDataQuality]).to eq(1)
       end
     end
   end

--- a/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
+++ b/spec/models/grda_warehouse/tasks/client_cleanup_spec.rb
@@ -707,8 +707,8 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       end
     end
 
-    context 'when dob_selection_method is demote_oldest' do
-      let(:selection_method) { :demote_oldest }
+    context 'when dob_selection_method is oldest' do
+      let(:selection_method) { :oldest }
 
       it 'prefers the newer record whose DOB is possible' do
         result = cleanup.choose_best_dob(dest_attr, qa_source_clients)
@@ -737,8 +737,8 @@ RSpec.describe GrdaWarehouse::Tasks::ClientCleanup, type: :model do
       end
     end
 
-    context 'when dob_selection_method is demote_newest' do
-      let(:selection_method) { :demote_newest }
+    context 'when dob_selection_method is newest' do
+      let(:selection_method) { :newest }
 
       it 'delegates to DOBSelector, preferring the newest record' do
         expect(GrdaWarehouse::DOBSelector).to receive(:call).


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

- Adds `GrdaWarehouse::DOBSelector`, paralleling `SSNSelector`, ranking candidates on `[DOBDataQuality, validity, DateCreated, id]`
- A DOB is impossible when it postdates its record's `DateCreated` or precedes it by more than 150 years; impossible DOBs at DQ 1 or 2 are demoted to 2, value always kept
- Validity sorts ahead of `DateCreated`, so a demoted date cannot beat a genuinely approximate one on age
- New `dob_dq_demotion_enabled` config (migration, `known_configs`, admin form), **default false** — no behavior change until enabled
- `choose_best_dob` branches on the flag; today's body moved verbatim to `choose_best_dob_legacy`
- Specs: 447-line `dob_selector_spec.rb`, plus `client_cleanup_spec.rb` cases pinning the legacy path green and the flag-on path

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

