### PR TITLE
fix: 9590 attribute ACL import PaperTrail versions to the uploading user

### DIFF
--- a/app/models/access_control_upload.rb
+++ b/app/models/access_control_upload.rb
@@ -43,15 +43,18 @@ class AccessControlUpload < ApplicationRecord
     update(status: PROCESSED)
   end
 
+  # NOTE: this runs in a Delayed::Job. Set whodunnit explicitly
   def import!
-    self.class.transaction do
-      import_roles!
-      import_agencies! # NOTE: agencies need to be imported before users
-      import_users! # NOTE: users need to be imported before user groups
-      import_user_groups!
-      import_collections!
-      import_access_controls! # NOTE: this must come last
-      update(status: IMPORT_COMPLETE)
+    PaperTrail.request(whodunnit: user_id.to_s, controller_info: { user_id: user_id }) do
+      self.class.transaction do
+        import_roles!
+        import_agencies! # NOTE: agencies need to be imported before users
+        import_users! # NOTE: users need to be imported before user groups
+        import_user_groups!
+        import_collections!
+        import_access_controls! # NOTE: this must come last
+        update(status: IMPORT_COMPLETE)
+      end
     end
   end
 

--- a/spec/models/access_control_upload_spec.rb
+++ b/spec/models/access_control_upload_spec.rb
@@ -54,5 +54,39 @@ RSpec.describe AccessControlUpload, type: :model do
         expect(Collection.find_by_name('Approved Reports').reports.count).to eq(2)
       end
     end
+    # import! runs in a Delayed::Job, so nothing sets whodunnit for it the way
+    # ApplicationController does for a request
+    it 'attributes the versions it writes to the uploading user' do
+      GrdaWarehouse::WarehouseReports::ReportDefinition.maintain_report_definitions
+      access_control_upload.pre_process!
+      # Only inspect versions this import wrote, rather than relying on PaperTrail
+      # being disabled for everything that ran before it
+      max_version_id = GrPaperTrail::Version.maximum(:id) || 0
+      PaperTrailHelper.with_paper_trail do
+        # nothing outside the request cycle sets these
+        PaperTrail.request(whodunnit: nil, controller_info: {}) do
+          access_control_upload.import!
+        end
+      end
+
+      versioned_types = [
+        Role.sti_name,
+        UserGroup.sti_name,
+        UserGroupMember.sti_name,
+        AccessControl.sti_name,
+        Collection.sti_name,
+        Agency.sti_name,
+        User.sti_name,
+      ]
+      versions = GrPaperTrail::Version.
+        where(id: (max_version_id + 1)..).
+        where(item_type: versioned_types, event: 'create')
+      aggregate_failures do
+        expect(versions.count).to be > 0
+        expect(versions.map(&:item_type).uniq).to contain_exactly(*versioned_types)
+        expect(versions.pluck(:whodunnit).uniq).to eq([access_control_upload.user_id.to_s])
+        expect(versions.pluck(:user_id).uniq).to eq([access_control_upload.user_id])
+      end
+    end
   end
 end


### PR DESCRIPTION


## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
AccessControlUpload#import! runs as a Delayed::Job, so nothing set whodunnit and every version it wrote looked system-generated. Wrap the import in PaperTrail.request with the upload's user_id.

## Type of change
bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

