### PR TITLE
[#9582] Use the current version when displaying source data with no import

### DIFF
--- a/app/models/concerns/hmis_structure/base.rb
+++ b/app/models/concerns/hmis_structure/base.rb
@@ -27,7 +27,7 @@ module HmisStructure::Base
       # Handle classes that didn't exist previously
       return '2022' if self.class.in?([GrdaWarehouse::Hud::YouthEducationStatus])
 
-      '2020'
+      self.class.hud_csv_version
     end
   end
 

--- a/spec/models/grda_warehouse/hud/project_source_data_spec.rb
+++ b/spec/models/grda_warehouse/hud/project_source_data_spec.rb
@@ -24,13 +24,22 @@ RSpec.describe GrdaWarehouse::Hud::Project, 'project CSV driver extensions' do
       end
     end
 
-    it 'resolves imported_item_type to 2020 when FY2020 staging rows exist' do
+    it 'falls back to the current default HUD CSV version even when FY2020 staging rows exist' do
       HmisCsvTwentyTwenty::Importer::Project.create!(
         staging_attributes(project, importer_log),
       )
+      allow(HudHelper).to receive(:hud_csv_version).and_return('2099')
 
-      expect(project.imported_item_type(importer_log.id)).to eq('2020')
+      expect(project.imported_item_type(importer_log.id)).to eq('2099')
       expect(project.imported_items_2020.where(importer_log_id: importer_log.id)).to exist
+    end
+  end
+
+  describe 'imported_item_type fallback' do
+    it 'falls back to the current default HUD CSV version when no imported_items_* row matches' do
+      allow(HudHelper).to receive(:hud_csv_version).and_return('2099')
+
+      expect(project.imported_item_type(importer_log.id)).to eq('2099')
     end
   end
 


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Moves from a hard-coded 2020 to the current CSV version when displaying data in the HMIS Source view and the data can't be tied back to a particular import.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [ ] I ran the OP review skill
- [ ] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

