### PR TITLE
Comprehensive HMIS Forms documentation

### DIFF
--- a/docs/features/hmis/hmis-assessments.md
+++ b/docs/features/hmis/hmis-assessments.md
@@ -2,6 +2,8 @@
 
 The word "assessment" can refer to several related but distinct record types. This document clarifies what "assessment" may mean in different contexts.
 
+Every assessment is collected with a form definition. See [Form definitions](hmis-form-definitions.md) for what a definition and role are and how statuses work, and [Form resolution](hmis-form-resolution.md#choosing-a-definition-for-an-existing-record) for why unlocking a submitted assessment can switch it to a newer version of the form.
+
 The UI instructions below are developer documentation, intended to help new developers orient themselves in a local environment. They should not be taken as-is for customer-facing feature documentation.
 
 ## Quick reference

--- a/docs/features/hmis/hmis-form-authoring.md
+++ b/docs/features/hmis/hmis-form-authoring.md
@@ -1,0 +1,203 @@
+# HMIS form authoring
+
+How to build the JSON structure of a form definition — the `definition` blob itself.
+
+The authoritative source for what is *allowed* is the JSON schema at `drivers/hmis_external_apis/public/schemas/form_definition.json`. What is *rejected*, and with what message, is `Hmis::Form::DefinitionValidator`. When this doc disagrees with either, they win. Both run on publish and on seed, so most malformed JSON fails loudly and early; this doc does not enumerate what they already catch.
+
+Out of scope here:
+
+- Statuses, the draft/publish/retire lifecycle, and roles — [Form definitions](hmis-form-definitions.md)
+- How `rule` / `custom_rule` / `data_collected_about` behave at runtime — [Form resolution](hmis-form-resolution.md)
+- How JSON files on disk are loaded, and how fragments and patches resolve — [Form seeding](hmis-form-seeding.md)
+- How a submission becomes records — [Form processing](hmis-form-processing.md)
+
+## The definition object
+
+The top level has exactly two allowed keys: `item`, required, with at least one entry, and `name`, optional and read by nothing. The user-facing title lives on the database record's `title` column, not in the JSON.
+
+```json
+{ "item": [ ... ] }
+```
+
+Everything else lives in the recursive `item` tree. Each node has a `link_id`, a `type`, and type-specific properties. A node with `"type": "GROUP"` may carry a child `item` array; that is the only nesting mechanism.
+
+Groups are structure and layout only. They hold children, collect no value, may not have a `mapping`, and are skipped by `Hmis::Form::Definition#link_id_item_hash` — which value validation, assessment-date lookup, and numeric validation all iterate. Groups are also the unit of visibility: if filtering removes every child, the group goes too.
+
+Group-only properties are `prefill`, which adds the "fill from a previous assessment" button on top-level groups of HUD assessments, and `component` for layout (`TABLE`, `HORIZONTAL_GROUP`, `INPUT_GROUP`, `INFO_GROUP`, `DISABILITY_TABLE`, `SIGNATURE`, `SIGNATURE_GROUP`).
+
+Files on disk may use a `fragment` key in place of an item. That is a seeding-time construct resolved before validation — see [Form seeding](hmis-form-seeding.md).
+
+## Item types
+
+`type` is required on every node. The full list is `Types::Forms::Enums::ItemType`.
+
+- Structure and text: `GROUP`, `DISPLAY`. Neither collects a value.
+- Free text: `STRING` (one line), `TEXT` (multi-line).
+- Numbers: `INTEGER`, `CURRENCY` (up to two decimals). These are the only types with server-side format and bounds checking.
+- `BOOLEAN`, `DATE`, `TIME_OF_DAY`.
+- Lists: `CHOICE`, `OPEN_CHOICE` (allows a value not on the list). Both require a pick list. Multi-select is `repeats: true`, not a separate type.
+- Uploads: `FILE`, `IMAGE`. A form containing either cannot be saved in progress.
+- Composite: `OBJECT`, rendered by `component` as `NAME`, `ADDRESS`, `PHONE`, or `EMAIL`. `GEOLOCATION` for captured coordinates.
+
+Set `assessment_date: true` on the one `DATE` item that is the assessment date.
+
+## `link_id`
+
+Required on every node, groups included. Pattern is `^[a-zA-Z_$][a-zA-Z0-9_$]*$`: letters, digits, underscore, `$`, never leading with a digit. No dashes, dots, or spaces. Must be unique across the whole tree, not just within a group.
+
+`link_id` is the stable handle for everything that refers to an item: stored answers are keyed by it; `enable_when.question`, `bounds.question`, and `autofill_values.value_question` reference it; environment patches target it; HUD assessments must contain specific ones for their role; and an auto-created Custom Data Element derives its key from it.
+
+Renaming a link ID on a published form is therefore permanent damage — it orphans every stored answer under the old ID. Nothing validates this.
+
+## `mapping`
+
+`mapping` says where an answer is stored. Exactly one of `field_name` or `custom_field_key` is required when `mapping` is present.
+
+**A HUD or record field.** `field_name` is the camelCase GraphQL field on the target type. `record_type` selects which related record receives it; omit it to write to the form's own owner record.
+
+```json
+"mapping": { "record_type": "HEALTH_AND_DV", "field_name": "pregnancyStatus" }
+```
+
+Valid `record_type` values are defined in `Hmis::Form::RecordType`: `ASSESSMENT` (the HUD CE assessment), `CLIENT`, `CURRENT_LIVING_SITUATION`, `DISABILITY_GROUP`, `EMPLOYMENT_EDUCATION`, `ENROLLMENT`, `EVENT`, `EXIT`, `HEALTH_AND_DV`, `INCOME_BENEFIT`, `YOUTH_EDUCATION_STATUS`, and `GEOLOCATION`. Each targets the same-named model, with two exceptions: `DISABILITY_GROUP` fans out to several `Disabilities` records, and `GEOLOCATION` writes to the `Enrollment`.
+
+**A Custom Data Element.** The answer is stored as a `CustomDataElement` against a `CustomDataElementDefinition` (CDED) with that key. Add `record_type` alongside it to move the CDED's owner off the form's default owner.
+
+```json
+"mapping": { "custom_field_key": "tb_flagged_date" }
+```
+
+The owner is `RecordType.find(record_type).owner_type` when `record_type` is set, otherwise the form role's `owner_class`. A CDED is then looked up by owner type, key, and data source. **Keys are unique per owner type, not globally** — the same key on `Client` and on `CustomAssessment` is two unrelated CDEDs.
+
+What happens when the CDED is missing depends on how the form arrives. `PublishFormDefinition` creates it, deriving the key from the link ID if none was given. Seeding does not create it, so a version-controlled form must name a `custom_field_key` that already exists. The CDED's `reporting_key` is always derived, never authored.
+
+**No mapping.** Omit `mapping` for display and layout items. An *input* item with no mapping collects a value that is persisted nowhere, and nothing warns you.
+
+## Conditional logic and filtering
+
+Three mechanisms decide whether a user sees an item. They are not interchangeable.
+
+| Property | Evaluated | Against | Effect |
+| --- | --- | --- | --- |
+| `enable_when` | Front-end, live as the user types | Other answers on this form, or a local constant | Item is disabled; `disabled_display` decides whether it hides |
+| `rule` / `custom_rule` | Server, when the definition is served | The project, its type, and its funders | Item is removed from the returned definition |
+| `data_collected_about` | Front-end, when the form is rendered | The client and their relationship to head of household | Item is removed from the rendered definition |
+
+A disabled item is still in the definition and returns as soon as its dependency changes. A filtered item is gone for that project or client, and no answer for it can be submitted.
+
+### `enable_when` and `enable_behavior`
+
+`enable_when` is an array of conditions; `enable_behavior` is `ALL` or `ANY`. Each condition takes exactly one source — `question` (a link ID) or `local_constant` — and exactly one comparison value out of `answer_code`, `answer_codes`, `answer_group_code`, `answer_number`, `answer_boolean`, `answer_date`, or `compare_question`. `operator` is one of `EQUAL`, `NOT_EQUAL`, `EXISTS`, `ENABLED`, `IN`, `INCLUDES`, `EXCLUDES`, `GREATER_THAN`, `GREATER_THAN_EQUAL`, `LESS_THAN`, `LESS_THAN_EQUAL`.
+
+```json
+{
+  "type": "GROUP",
+  "link_id": "R10_1_conditionals",
+  "enable_behavior": "ALL",
+  "enable_when": [{ "question": "R10_1", "operator": "EQUAL", "answer_code": "YES" }],
+  "item": [ ... ]
+}
+```
+
+Putting the condition on a wrapping group, as above, is the idiomatic way to show or hide several items together.
+
+`local_constant` names a value supplied by the rendering context, written with a leading `$`. Real forms use `$today`, `$entryDate`, `$exitDate`, `$hudRecordType`, and `$hudTypeProvided`. Which are available depends on where the form is rendered, so copy from a form of the same role rather than guessing.
+
+`disabled_display` is `HIDDEN` (the default), `PROTECTED`, or `PROTECTED_WITH_VALUE`.
+
+### `rule` and `custom_rule`
+
+Both hold a rule object evaluated by `Hmis::Form::DefinitionItemFilter` when the definition is served. `rule` is HUD-derived; `custom_rule` is yours. When both are present the item is kept if *either* passes. With no rule, the item is always kept.
+
+Leaf rules are `{ variable, operator, value }`:
+
+| `variable` | Operators | `value` |
+| --- | --- | --- |
+| `projectType` | `EQUAL`, `NOT_EQUAL` | HUD project type integer |
+| `projectId` | `EQUAL`, `NOT_EQUAL` | string |
+| `projectFunders` | `INCLUDE`, `NOT_INCLUDE` | HUD funder integer |
+| `projectFunderComponents` | `INCLUDE`, `NOT_INCLUDE` | string such as `"HUD: CoC"` |
+| `projectOtherFunders` | `INCLUDE`, `NOT_INCLUDE` | string, compared case-insensitively |
+
+Compose with `{ "operator": "ANY", "parts": [ ... ] }` or `ALL`.
+
+### `data_collected_about`
+
+Allowed on groups and input items. Values are `ALL_CLIENTS` (the default when unset), `HOH`, `HOH_AND_ADULTS`, `ALL_VETERANS`, and `VETERAN_HOH`. A client of unknown age counts as an adult.
+
+## Initial values and autofill
+
+`initial` sets a value once on load. Each entry needs `initial_behavior` — `IF_EMPTY` or `OVERWRITE` — and exactly one value source out of `value_code`, `value_number`, `value_boolean`, or `value_local_constant`.
+
+`autofill_values` keeps recomputing a value. Each entry takes exactly one source out of `value_code`, `value_number`, `value_boolean`, `value_question`, `sum_questions`, or `formula`, plus an optional `autofill_when` array with the same shape and rules as `enable_when`. With no `autofill_when` the autofill always runs. `autofill_behavior` defaults to `ANY`; `autofill_readonly: true` also runs it in read-only views.
+
+A `DISPLAY` item may carry either, to show a computed value.
+
+## Pick lists
+
+`CHOICE` and `OPEN_CHOICE` require exactly one of `pick_list_options` or `pick_list_reference`.
+
+Static options need only `code`, which is what gets stored. `label`, `helper_text`, `numeric_value` for scoring, and `group_code` / `group_label` for grouping are optional — a `group_code` is what `enable_when.answer_group_code` compares against.
+
+```json
+"pick_list_options": [{ "code": "YES", "label": "Yes" }, { "code": "NO", "label": "No" }]
+```
+
+A `pick_list_reference` is either a `Types::Forms::Enums::PickListType` value, resolved server-side and often needing project or client context (see `pick_list_type.rb` and `pick_list_option.rb`), or any GraphQL enum name such as `NoYesReasonsForMissingData`, resolved in the front-end. The two share one namespace and the validator accepts the union.
+
+`component` narrows rendering: `DROPDOWN`, `RADIO_BUTTONS`, `RADIO_BUTTONS_VERTICAL`, `CHECKBOX`.
+
+## Validation-affecting properties
+
+| Property | Effect |
+| --- | --- |
+| `required` | Missing or empty value is an error at submit |
+| `warn_if_empty` | Missing value, or `DATA_NOT_COLLECTED`, is a warning instead |
+| `bounds` | Min/max, see below |
+| `repeats` | Value is an array. Must match the CDED's `repeats` when mapped to a custom field |
+| `read_only` | No human editing |
+| `hidden` | Always hidden, and exempt from the `text` requirement |
+
+`required` and `warn_if_empty` are only checked for link IDs actually present in the submission, so an item removed by a rule or by `data_collected_about` never blocks submission.
+
+`bounds` are allowed on `INTEGER`, `CURRENCY`, `DATE`, `STRING`, and `TEXT`; on string types the bound is a character count. Each needs `id` and `type` (`MIN` or `MAX`) plus exactly one of `value_number`, `value_date`, `value_local_constant`, or `question`. `offset` shifts the comparison, in days for dates. `severity` defaults to `error`.
+
+```json
+"bounds": [
+  { "id": "min-service-date", "type": "MIN", "value_local_constant": "$entryDate" },
+  { "id": "max-fa-start", "type": "MAX", "question": "faEndDate" }
+]
+```
+
+## Gotchas
+
+The schema and validator catch malformed JSON on their own, so this list covers only what they *don't*.
+
+- **Only the first `initial` entry applies.** Extra entries are silently ignored, so multiple initial values for a multi-select do not work.
+- **Four `record_type` values are schema-valid but unimplemented.** `PROJECT`, `ORGANIZATION`, `CE PARTICIPATION`, and `SERVICE` pass schema validation and then raise `NoMethodError` during CDED generation, because `Hmis::Form::RecordType` doesn't define them. Don't use them.
+- **Most bounds are not enforced server-side.** `NumericInputValidator` checks only `INTEGER` and `CURRENCY`, only non-warning severity, and only bounds expressed as a literal `value_number`. A bound against another question, a local constant, or a date is front-end only.
+- **Neither is conditional logic.** `enable_when` and item-level `data_collected_about` are evaluated in the browser and never re-checked on submit, so a non-UI caller can write values for questions the form would have hidden. See [Form processing](hmis-form-processing.md#who-enforces-what).
+- **`set_hud_requirements` overwrites what you wrote.** On HUD assessment forms it rewrites `rule` — so don't hand-author it there — and relaxes `data_collected_about` to the less strict of the HUD requirement and yours. It never tightens.
+- **An input item with no `mapping` silently discards its answer.** Valid JSON, no warning, no persisted value.
+- **`DATA_NOT_COLLECTED` and `_HIDDEN` bypass numeric validation** rather than failing format checks.
+- **A CDED key may contain dashes; a `link_id` may not.** So an auto-generated key can never have one, but a hand-authored key can.
+- **Don't let every item be filtered out.** A form whose questions are all ruled out for a project fails the GraphQL query at runtime, not at authoring time. See [Form resolution](hmis-form-resolution.md#item-level-filtering).
+
+Use `_comment` to leave notes. It is accepted on the item, `mapping`, `bounds`, `rule`, `initial`, `enable_when`, and `autofill_values` objects, and it is the only free-form key the schema allows anywhere.
+
+## Real forms to copy from
+
+Prefer copying a form of the same role over writing from scratch, since local constants and required link IDs vary by role. Under `drivers/hmis/lib/form_data/`:
+
+- `default/fragments/r10_pregnancy_status.json` — a group scoped with `data_collected_about`, a `CHOICE` mapped to `HealthAndDv`, and a conditional child group with a date bound
+- `tarrant_county/fragments/client_tb_dates.json` — several items mapped to Custom Data Elements with no `record_type`
+- `test/custom_assessments/cls_assessment.json` — one form mixing an assessment date, HUD `CurrentLivingSituation` fields, and a CDE
+- `default/records/` — the system record forms (Client, Project, Funder, Inventory)
+
+## Related
+
+- [Form definitions](hmis-form-definitions.md) — the definition model, roles, and statuses
+- [Form resolution](hmis-form-resolution.md) — which form applies to a project, and item-level filtering
+- [Form seeding](hmis-form-seeding.md) — loading definitions from JSON, fragments, and patches
+- [Form processing](hmis-form-processing.md) — turning a submission into records
+- [HMIS assessments](hmis-assessments.md) — what the assessment roles collect

--- a/docs/features/hmis/hmis-form-definitions.md
+++ b/docs/features/hmis/hmis-form-definitions.md
@@ -1,0 +1,96 @@
+# HMIS form definitions
+
+Nearly all data entry in the HMIS front-end is driven by a **form definition**. This document covers the `Hmis::Form::Definition` model itself — its columns, its roles, and its status lifecycle. It is the entry point to the other form docs.
+
+| Concept | Model / table | What it answers | Documented in |
+| --- | --- | --- | --- |
+| Form definition | `Hmis::Form::Definition` / `hmis_form_definitions` | What questions does this form ask, and is this version live? | This doc |
+| The definition JSON | the `definition` column | How do I write or change the questions? | [Form authoring](hmis-form-authoring.md) |
+| Form rule | `Hmis::Form::Instance` / `hmis_form_instances` | Which projects use this form, and which form does the app pick? | [Form resolution](hmis-form-resolution.md) |
+| Form processor | `Hmis::Form::FormProcessor` / `hmis_form_processors` | What happened when this form was submitted, and where did the data go? | [Form processing](hmis-form-processing.md) |
+| Custom Data Element | `Hmis::Hud::CustomDataElement` | Where do answers live that have no HUD field? | Below, briefly |
+| JSON files on disk | `drivers/hmis/lib/form_data/` | How do version-controlled forms get into the database? | [Form seeding](hmis-form-seeding.md) |
+
+## The definition model
+
+`Hmis::Form::Definition` (table `hmis_form_definitions`) is a versioned form schema. Its `definition` column holds a recursive JSON structure, loosely based on FHIR Questionnaire, describing inputs, labels, validation, and the `mapping` of each question to a HMIS field or Custom Data Element.
+
+Key columns:
+
+| Column | Meaning |
+| --- | --- |
+| `identifier` | Stable string shared across all versions of the same form. Form rules reference this, not `id` |
+| `role` | What the form collects (see [Roles](#roles)) |
+| `status` | `draft`, `published`, or `retired` (see [Lifecycle](#lifecycle)) |
+| `version` | Integer, incremented when a new draft is created for an identifier |
+| `data_source_id` | Scopes the definition to an HMIS data source |
+| `managed_in_version_control` | True if the definition came from a JSON file on disk rather than the Form Builder |
+| `admin_editable_only` | Restricts editing to super-admins (`Hmis::AuthPolicies::FormDefinitionPolicy`) |
+| `external_form_object_key` | For `EXTERNAL_FORM` only: the key public submissions are filed under. Cannot be reused across identifiers |
+
+`identifier` + `version` is unique within a data source. A definition is never edited in place once published; a new version is created instead. The exception is seeded forms, [described below](#seeded-forms-are-always-published-and-overwritten).
+
+Answers that have no HUD field are stored as **Custom Data Elements**, keyed by a `custom_field_key` in the item's `mapping`. Publishing a form creates the matching `CustomDataElementDefinition` rows automatically. There is no dedicated CDE doc yet; the generation rules are covered in [Form authoring](hmis-form-authoring.md).
+
+## Roles
+
+A definition's `role` determines what record the form owns, which mutation submits it, and where it appears in the UI. Roles are declared in `Hmis::Form::Definition`, grouped as follows:
+
+| Group | Roles | Notes |
+| --- | --- | --- |
+| Assessment | `INTAKE`, `UPDATE`, `ANNUAL`, `EXIT`, `POST_EXIT`, `CUSTOM_ASSESSMENT` | Own a `CustomAssessment`; submitted via `SubmitAssessment`. Only these support save-in-progress. See [HMIS assessments](hmis-assessments.md) |
+| System record | `PROJECT`, `ORGANIZATION`, `PROJECT_COC`, `FUNDER`, `INVENTORY`, `CLIENT`, `NEW_CLIENT_ENROLLMENT`, `ENROLLMENT`, `HMIS_PARTICIPATION`, `CE_PARTICIPATION` | Required for basic HMIS function. Resolution raises if one is missing |
+| Data collection feature | `CURRENT_LIVING_SITUATION`, `SERVICE`, `CE_EVENT`, `CE_ASSESSMENT`, `CASE_NOTE`, `EXTERNAL_FORM`, `REFERRAL`, `REFERRAL_REQUEST` | Optional per-project features, toggled on by an active form rule. The two referral roles are deprecated |
+| Static | `FORM_RULE`, `PROJECT_CONFIG`, `CLIENT_ALERT`, `FORM_DEFINITION` | Admin config forms. Not configurable, need no rule, submitted by bespoke mutations |
+| Other | `OCCURRENCE_POINT`, `CLIENT_DETAIL`, `FILE`, `CE_REFERRAL_STEP` | |
+
+Everything except the assessment and static groups is a "record form," submitted via `SubmitForm`. `FORM_ROLE_CONFIG` maps each of those roles to its `owner_class` — the record type the form creates or edits.
+
+`EXTERNAL_FORM` is the one public-facing role. Those forms are filled out by the public rather than by staff, arrive through an S3 pipeline instead of a GraphQL mutation, and are reviewed in the HMIS before their data is accepted.
+
+Multiple published definitions can share a role. Which one applies to a given project is not determined by the role alone — see [Form resolution](hmis-form-resolution.md).
+
+## Lifecycle
+
+| Status | Offered for new data entry | Can submit | Can delete |
+| --- | --- | --- | --- |
+| `draft` | No | No | Yes |
+| `published` | Yes | Yes | No |
+| `retired` | No\* | Yes | No |
+
+\* Resolution only ever returns published definitions, so a retired form is never *offered*. It is not, however, refused: the front-end will open a new assessment against a retired definition if navigated to one directly by id (`NewIndividualAssessmentPage.tsx` accepts `Published` or `Retired`).
+
+Only one version per identifier can be `published` at a time. Publishing a draft (`PublishFormDefinition`) retires the previously published version in the same transaction. Editing a published form means creating the next draft version (`CreateNextDraftFormDefinition`), then publishing that. The Form Builder refuses to open anything but a draft.
+
+Deletion is restricted to drafts (`DeleteFormDefinition`), because published and retired definitions are referenced by `hmis_form_processors` rows on existing records. Retiring is the only way to take a form out of circulation.
+
+`valid_status_for_submit?` allows both `published` and `retired`, so a retired definition can still be submitted. This is deliberate: it keeps existing records editable after their form is retired. Which definition the UI actually uses to edit an old record — the original or a newer one — depends on the record type, and is covered in [Form resolution](hmis-form-resolution.md#choosing-a-definition-for-an-existing-record).
+
+### Seeded forms are always published, and overwritten
+
+Definitions loaded from JSON (`managed_in_version_control: true`) do not participate in the draft/publish cycle. `HmisUtil::JsonForms#load_definition` upserts a single row per identifier at `version: 0`, overwrites its `definition` JSON from the file, and forces `status` to `published` on every run. There is no version history and no retired predecessor.
+
+Two things follow:
+
+- Local edits to a seeded form through the Form Builder are lost on the next deploy or `rails driver:hmis:seed_definitions`. The Form Builder shows an alert on these forms and offers "Duplicate" instead.
+- Adding a JSON file for an identifier that is deliberately retired will publish it. Avoid version control for any form whose value depends on staying retired.
+
+## Version control or Form Builder?
+
+Forms can either be managed in version control (JSON files under `drivers/hmis/lib/form_data/`) or managed in the Form Builder in-app. This is a per-form decision with real consequences, since seeded forms are overwritten on deploy.
+
+**Prefer version control** for anything that collects **HUD fields** and must **stay HUD-compliant over time** — the Client form, HUD Service collection form, Current Living Situation, intake and exit assessments, the Project form, and the other definitions that ship under `default/`. Any form that is essential to application function, such that the app would crash without it, also belongs in version control.
+
+**Do not manage in version control** forms that are **customer-specific and non-HUD**: custom assessments, service forms for custom (non-HUD) services, case note forms, non-HUD occurrence point forms, client details forms, and similar tenant-only content. Build those in the Form Builder. Service forms and custom assessments in particular should never be added to `form_data/`.
+
+**Patches and environment overrides** are for a customer-specific change to a HUD-compliant form — an extra field on the Client form, or extra sections on a HUD assessment. Those live under the client's directory and are applied per `ENV['CLIENT']`; see [Form seeding](hmis-form-seeding.md).
+
+## Related
+
+- [Form resolution](hmis-form-resolution.md) — form rules, which definition applies where, and item-level filtering
+- [Form authoring](hmis-form-authoring.md) — writing the definition JSON
+- [Form processing](hmis-form-processing.md) — what happens on submit, and where the data lands
+- [Form seeding](hmis-form-seeding.md) — loading definitions from JSON and maintaining HUD compliance rules
+- [HMIS assessments](hmis-assessments.md) — what the assessment roles collect, and the record types behind them
+- [Multi-HMIS support](multi-hmis-support.md) — why definitions carry `data_source_id`, and which config tables are not yet fully scoped
+- [CE workflow builders](ce-workflow-builders.md) — `WorkflowDefinition::Template` uses a parallel draft/publish/retire lifecycle

--- a/docs/features/hmis/hmis-form-processing.md
+++ b/docs/features/hmis/hmis-form-processing.md
@@ -1,0 +1,202 @@
+# HMIS form processing
+
+What happens between a user pressing Submit and data landing in database records. The central class is `Hmis::Form::FormProcessor`, which is both an ActiveRecord model (table `hmis_form_processors`) and the engine that turns a submitted payload into HUD records.
+
+Out of scope here:
+
+- Statuses and roles — [Form definitions](hmis-form-definitions.md)
+- Form rules and which definition applies — [Form resolution](hmis-form-resolution.md)
+- The shape of the definition JSON, including `mapping`, `link_id`, and pick lists — [HMIS form authoring](hmis-form-authoring.md)
+- Loading definitions from JSON files on disk — [HMIS form seeding](hmis-form-seeding.md)
+
+## Overview
+
+Every submission path converges on the same sequence.
+
+1. **Resolve the definition.** Looked up by ID and scoped to the user's data source. Must have a submittable status (`submit_form.rb:28-30`).
+2. **Find or build the owner record.** The "owner" is the primary record the form is about: a `Client`, `Project`, `CustomAssessment`, and so on. For creates, `Hmis::Form::SubmitFormRecordInitializer` builds an unsaved record and resolves associations from the input (`submit_form_record_initializer.rb:79-100`).
+3. **Authorize.** `Hmis::Form::SubmitFormAuthorizer` checks a policy chosen by owner class and action (`submit_form_authorizer.rb:30-89`).
+4. **Attach the payload.** The owner's `FormProcessor` is found or built, pointed at the definition, and given both `values` and `hud_values` (`submit_form.rb:45-48`).
+5. **Validate the form values** against the definition — required fields, numeric formats, warnings (`form_processor.rb:542-544`).
+6. **Run the processor.** `run!` assigns attributes onto in-memory records. Nothing is saved yet (`form_processor.rb:76-132`).
+7. **Validate the records.** ActiveRecord validations plus HMIS validator classes (`form_processor.rb:552-579`).
+8. **Return early on errors**, or save. The mutation saves the owner, then the `FormProcessor`, which autosaves the related HUD records (`submit_form.rb:66-97`).
+
+Steps 5 through 8 all happen inside one transaction (`submit_form.rb:18-22`).
+
+## Submission approaches
+
+There is no single submit mutation. Which one the front-end calls depends on the form's role.
+
+| Approach | Mutation | Owner | Uses `FormProcessor` |
+| --- | --- | --- | --- |
+| Record forms | `SubmitForm` | Whatever `FORM_ROLE_CONFIG` says for the role | Yes |
+| Assessments | `SubmitAssessment`, `SaveAssessment` | `Hmis::Hud::CustomAssessment` | Yes |
+| Household assessments | `SubmitHouseholdAssessments` | Several `CustomAssessment`s at once | Yes |
+| CE referral steps | `Ce::SubmitCeReferralStep` | `Hmis::WorkflowExecution::Step` | Yes |
+| Static admin forms | Bespoke mutations per role | The config record itself | No |
+
+**Record forms** (`submit_form.rb`) are the general case. `SubmitForm` derives the owner class from the definition's role, builds or finds the record, authorizes, processes, and saves. It is the only path that runs the record initializer and the authorizer, and the only one that validates against a role-specific validation context in addition to `:form_submission` (`submit_form.rb:58`).
+
+**Assessments** (`submit_assessment.rb`) skip both of those classes. The owner is always a `CustomAssessment`, so authorization is a single enrollment `can_edit?` check performed while finding or creating the assessment (`assessment_input.rb:49`). In exchange, `SubmitAssessment` carries assessment-specific business rules that no other path has: head-of-household exit constraints, non-HoH intake constraints, and a block on exiting an incomplete enrollment (`submit_assessment.rb:56-82`). Saving is delegated to `CustomAssessment#save_submitted_assessment!`, which also saves the enrollment, flips the enrollment out of work-in-progress on intake, releases units on exit, and fires referral integrations (`custom_assessment.rb:172-200`).
+
+**Household assessments** (`submit_household_assessments.rb`) submit assessments for multiple household members together. It re-runs the same per-assessment validation loop, but passes `household_members:` into `collect_processing_validations` so that unsaved entry and exit dates on sibling enrollments are visible to date validation (`submit_household_assessments.rb:98-105`). Note that it does not accept `values`/`hud_values`; it processes what is already stored on each assessment's `FormProcessor` from a prior save. Both assessment mutations support `validate_only`, which runs everything and returns without saving.
+
+**CE referral steps** (`ce/submit_ce_referral_step.rb`) build a `FormProcessor` on a workflow step, run it to produce Custom Data Elements, and hand off to the workflow engine to complete the step. Validation comes from the engine, not from `collect_form_validations` (`submit_ce_referral_step.rb:42-53`).
+
+**Static forms** — `FORM_RULE`, `PROJECT_CONFIG`, `CLIENT_ALERT`, `FORM_DEFINITION` — use a form definition only to render the admin UI. Their mutations assign input straight onto the config record and never touch a `FormProcessor` (`create_form_rule.rb:20-33`, `create_project_config.rb:23-31`). Nothing in this document after this point applies to them.
+
+**External forms** are a fifth path. `HmisExternalApis::ExternalForms::FormSubmission` runs the processor at review time, deliberately skipping both validation phases because the submitter is long gone and cannot fix anything (`form_submission.rb:141-148`).
+
+## `values` and `hud_values`
+
+A submission carries the same answers twice, in two differently keyed JSON blobs. Both are stored on `hmis_form_processors` as `jsonb`.
+
+| | `values` | `hud_values` |
+| --- | --- | --- |
+| Keyed by | `link_id` | `Container.fieldName`, or bare `fieldName` |
+| Example | `{"ssn": "123456789"}` | `{"Client.ssn": "123456789"}` |
+| Used for | Validating against the definition; finding the assessment date; re-rendering | Writing to the database |
+
+`collect_form_validations` and `find_assessment_date_from_values` read `values` (`form_processor.rb:502-510`, `540-544`). Everything in `run!` reads `hud_values`. If `hud_values` is blank, `run!` returns immediately and no record is touched (`form_processor.rb:81`).
+
+The front-end computes `hud_values` from the definition's `mapping` before submitting; the server does not derive one from the other.
+
+## Container processors
+
+`run!` splits `hud_values` into containers, then routes each field to a processor.
+
+### Routing
+
+`hud_values_by_container` turns `{"HealthAndDv.field1" => nil, "IncomeBenefit.field1" => 3}` into `{"HealthAndDv" => {"field1" => nil}, "IncomeBenefit" => {"field1" => 3}}` (`form_processor.rb:138-146`). A key with no dot belongs to the owner's own container, named after the owner class with two exceptions: `Hmis::Hud::Assessment` becomes `CeAssessment`, and `Hmis::WorkflowExecution::Step` becomes `WorkflowStep` (`form_processor.rb:156-177`).
+
+The container name maps to a processor class through the frozen `valid_containers` hash (`form_processor.rb:401-435`). There are 27 entries pointing at the classes in `drivers/hmis/app/models/hmis/hud/processors/`; consult that hash rather than reproducing it. `Hmis::Form::RecordType` is the other half of the mapping: it translates a definition's `mapping.record_type` (for example `HEALTH_AND_DV`) into the same container name (`record_type.rb:22-85`, `form_processor.rb:646-655`).
+
+Each field must be recognized before it is processed. `mapped_record_form_fields` and `mapped_custom_form_fields` walk the definition's items and collect, per container, the set of `field_name`s and `custom_field_key`s it declares (`form_processor.rb:599-627`). A field in the first set goes to `process`; a field in the second goes to `process_custom_field`; anything else raises (`form_processor.rb:98-106`). The definition's mappings are, in effect, the allowlist for what a submission may write.
+
+### The base processor and name translation
+
+`Hmis::Hud::Processors::Base#process` is three lines and does the whole translation (`base.rb:24-29`):
+
+```ruby
+def process(field, value)
+  attribute_name = ar_attribute_name(field)
+  attribute_value = attribute_value_for_enum(graphql_enum(field), value)
+
+  @processor.send(factory_name)&.assign_attributes(attribute_name => attribute_value)
+end
+```
+
+The name path has three hops:
+
+1. **GraphQL camelCase to AR attribute.** `ar_attribute_name` is `field.underscore`, so `veteranStatus` becomes `veteran_status` (`base.rb:62-64`).
+2. **AR attribute to HUD column.** The HUD models alias every CSV column to its snake_case form. `HmisStructure::Shared` iterates the HMIS CSV configuration for each supported spec year and calls `alias_attribute col.underscore, col`, so `veteran_status` resolves to `VeteranStatus` (`shared.rb:15-25`). `Hmis::Hud::Base.alias_to_underscore` does the same for a few common fields and for non-CSV models (`base.rb:75-82`).
+3. **Value translation.** `graphql_enum(field)` looks the field up on the subclass's `schema` — the GraphQL type for that record, such as `Types::HmisSchema::HealthAndDv` — and returns the enum type if the field is one (`base.rb:67-91`). `attribute_value_for_enum` then converts (`base.rb:100-117`):
+
+| Input | Stored |
+| --- | --- |
+| `'CLIENT_PREFERS_NOT_TO_ANSWER'` | `9` |
+| `['PH', 'ES_NBN']` | `[10, 1]` |
+| `nil` or `''` | the enum's data-not-collected value, usually `99` |
+| `'_HIDDEN'` | `nil` |
+| anything with no enum | passed through unchanged |
+
+`'_HIDDEN'` is `Base::HIDDEN_FIELD_VALUE`, the sentinel the front-end sends for a question that `enable_when` hid (`base.rb:15-16`). Interpreting it is centralized in `attribute_value_for_enum`, so hiding a question clears the underlying column. Several processors special-case that, notably `ClientProcessor` for SSN and DOB, which are hidden for lack of permission rather than by conditional logic and so must be left alone (`client_processor.rb:19-20`, `33-40`).
+
+The record being assigned comes from `factory_name`, a method on the `FormProcessor` that finds or builds the record and stores it on the association — `health_and_dv_factory`, `income_benefit_factory`, and so on (`form_processor.rb:265-384`). Subclasses supply only `factory_name`, `relation_name`, and `schema`; `HealthAndDvProcessor` is 23 lines and typical (`health_and_dv_processor.rb`).
+
+Subclasses override `process` when a field is not a simple column assignment. Examples: `ClientProcessor` fans race and gender out to individual HUD columns and builds nested name, address, and contact records; `IncomeBenefitProcessor` forces dependent income fields to match the overarching "from any source" answer (`income_benefit_processor.rb:39-92`); `DisabilityGroupProcessor` routes one container across six different disability factories (`disability_group_processor.rb:52-75`); `GeolocationProcessor` parses coordinates and destroys the location record when they are absent.
+
+### Metadata and the second pass
+
+After every field is assigned, `run!` makes a second pass over the containers to call `assign_metadata`, `information_date`, and `post_process` on each processor (`form_processor.rb:114-129`). `assign_metadata` sets the HUD user and data source; `information_date` stamps the assessment date onto related records. `post_process` is where cross-field work lands, such as `ClientProcessor` reconciling `RaceNone`/`GenderNone` and `CustomAssessmentProcessor` recalculating the Alt-AHA score to confirm the submitted one is still current.
+
+Finally, if the owner is a `CustomAssessment`, its enrollment is reattached so the mutation can save it (`form_processor.rb:131`).
+
+### Custom data elements
+
+A field mapped with `custom_field_key` goes to `process_custom_field` (`base.rb:146-201`). The processor looks up the `CustomDataElementDefinition` by key and owner type, normalizes the value against the definition's `field_type`, then builds `custom_data_elements_attributes` on the record — updating a single-valued element in place, or diffing submitted against existing values for a repeating one. The elements save when the owner record saves, via `accepts_nested_attributes_for` in `Hmis::Hud::Concerns::FormSubmittable` (`form_submittable.rb:17-22`). An unknown key raises.
+
+The definitions themselves are created at form-authoring time, not at submission time, by `Hmis::Form::CustomDataElementGenerator` (`custom_data_element_generator.rb:43-102`). By the time a form is submitted, every `custom_field_key` in it is expected to already exist.
+
+## Validation
+
+Three phases run in order, and they answer different questions.
+
+| Phase | Method | Reads | Catches |
+| --- | --- | --- | --- |
+| Form validation | `collect_form_validations` | `values` | Missing required answers, numeric format, empty-but-expected warnings |
+| Record validation | `record.valid?(...)` | in-memory records | ActiveRecord validations on the owner and, via `hmis_records_are_valid`, on every related record |
+| Processing validation | `collect_processing_validations` | in-memory records | AR errors as user-facing errors, assessment date rules, HMIS validator classes, errors raised by processors |
+
+Phase one delegates to `Hmis::Form::Definition#validate_form_values`, which walks the definition in order so errors come back sorted the way the form reads (`definition.rb:476-518`). Phase three collects ActiveRecord errors, filtering out ID fields, relation errors, and information-date errors on assessments, then adds `CustomAssessmentValidator` date checks and any `Hmis::Hud::Validators::BaseValidator` results for the current role (`form_processor.rb:514-579`).
+
+Processors can contribute to phase three directly by calling `add_processing_error` (`form_processor.rb:58-62`). The Alt-AHA score check is the example in the tree.
+
+### Who enforces what
+
+Much of a form definition is interpreted only in the browser. The server is a genuine second line of defense for some properties and no defense at all for others, so do not assume that a valid submission implies the client honored the definition.
+
+| Property | Client | Server |
+| --- | --- | --- |
+| `required` | Blocks submit | Re-checked in phase one (`definition.rb:476-518`) |
+| Numeric format, `INTEGER` / `CURRENCY` | Input type only | Re-checked by `NumericInputValidator` |
+| `bounds` | Sets the input's `min` / `max` | Only bounds with a literal `value_number` and non-warning severity; bounds against another question or a local constant are **not** checked (`numeric_input_validator.rb:44-45`) |
+| `enable_when` visibility | Authoritative | Never re-evaluated. The server trusts the omission, or `_HIDDEN` for a mapped field |
+| `autofill_values`, `initial` | Computed continuously | Never recomputed |
+| Item-level `data_collected_about` | Applied per client for household assessments | Not applied; the full definition is returned |
+| Pick list answer codes | Renders the options | Checked when the form is published, not on submit |
+
+The practical consequence is that the shape of a submission is decided client-side. A caller that is not the HMIS front-end — a script, a test, or a hand-built payload — can write values for questions the definition would have hidden, and only ActiveRecord validations stand in the way.
+
+### Warnings and `confirmed`
+
+Every error carries a `severity`, defaulting to `:error` (`error.rb:11`). Warnings come from two places: an item with `warn_if_empty` that was left blank or answered "data not collected" (`definition.rb:507-508`), and HMIS validator classes that flag a value as suspicious but legal.
+
+The front-end shows warnings in a confirmation dialog. If the user accepts them, it resubmits with `confirmed: true`, and the mutation calls `errors.drop_warnings!` before deciding whether to abort (`submit_form.rb:64`, `submit_assessment.rb:109`, `submit_household_assessments.rb:109`). Errors converted from ActiveRecord are always `:error` and can never be confirmed away (`error.rb:60`).
+
+`deduplicate!` runs last, preferring the copy of an error that carries a `link_id` because it has more context for the UI (`errors.rb:53-65`).
+
+## Work-in-progress assessments
+
+Only assessment roles can be saved in progress, and only if the form contains no `FILE` or `IMAGE` item (`definition.rb:430-438`).
+
+`SaveAssessment` assigns `values` and `hud_values` onto the `FormProcessor`, validates only the assessment date, and saves with `as_wip: true` (`save_assessment.rb:27-43`). It never calls `run!`. The answers exist solely as JSON in the two columns; no `IncomeBenefit`, `HealthAndDv`, `Exit`, or other related record has been created, and none of the `*_id` columns on `hmis_form_processors` are populated (`form_processor.rb:9-11`).
+
+That is the whole difference between a WIP and a submitted assessment. On the WIP save path, `save_submitted_assessment!` saves the processor and marks the assessment `wip: true`, skipping the enrollment save, the CE assessment questions job, and all the intake and exit side effects (`custom_assessment.rb:172-200`).
+
+Two consequences worth internalizing:
+
+- WIP answers are invisible to reporting, HUD exports, and any query against HUD tables. They are searchable only as JSON.
+- Warnings do not gate a WIP save, and required-field validation does not run at all. A half-finished assessment saves cleanly.
+
+When the assessment is finally submitted, the front-end re-sends the full payload and `SubmitAssessment` runs the processor for the first time, creating all the related records at once.
+
+## Footguns
+
+**An unmapped `hud_values` key is a 500.** Any field not declared in the definition's mappings raises (`form_processor.rb:105`). A front-end that caches a definition across a form change, or a hand-written payload, produces a server error rather than a validation error.
+
+**An unrecognized container also raises, despite appearances.** `container_processor` looks like it degrades gracefully in production — it captures a Sentry message and returns `nil` (`form_processor.rb:389-395`) — but the only caller in the field loop raises immediately on a nil processor (`form_processor.rb:90`). Since the metadata loop iterates the same container set, the production fallback is unreachable. Treat an invalid container as fatal in every environment.
+
+**`editor_user_ids` skips silently.** When an item restricts editing to specific users, a submission from anyone else has that field dropped with no error and no record of the attempt (`form_processor.rb:92-96`). The comment explains why: the front-end sends all values regardless, so raising would break legitimate submissions. The user sees a successful save that did not save their edit.
+
+**Hiding every field of a container can delete a record.** On a `CustomAssessment`, if all of a container's fields came in as `_HIDDEN` and its processor is `dependent_destroyable?`, the related record is destroyed rather than updated (`form_processor.rb:118-122`, `150-154`). Only four processors opt in: CE event, CE assessment, current living situation, and geolocation. This is how a conditionally collected record disappears when its condition goes false — and how one gets deleted unintentionally by an `enable_when` change.
+
+**Empty and hidden are not the same.** Empty becomes `99` when the field has an enum type, hidden becomes `nil` (`base.rb:100-117`). Adding an `enable_when` that hides an already-populated question will null the column on the next submission.
+
+**Enrollment is not one of the processor's associations.** It is reached through `enrollment_factory`, which infers it from the owner (`form_processor.rb:214-233`), so `form_processor.save!` does not save it. Every caller has to save the enrollment itself (`submit_form.rb:92-97`, `custom_assessment.rb:187-189`). A new submission path that forgets this will silently drop enrollment changes.
+
+**A form that submits only `values` writes nothing.** `run!` returns early when `hud_values` is blank (`form_processor.rb:81`), without error.
+
+**`collect_processing_validations` does not run every relevant validator.** It picks the validator off each *related* record, in the context of the definition's role. An enrollment form that also creates a client will not run the client validator, as the TODO in the code says (`form_processor.rb:564-572`).
+
+**Two mutations duplicate household business rules.** `SubmitAssessment` and `SubmitHouseholdAssessments` each carry their own copy of the HoH exit and non-HoH intake checks, with slightly different wording, and both are marked `FIXME` to move into `CustomAssessmentValidator` (`submit_assessment.rb:54`, `submit_household_assessments.rb:53`).
+
+## Related
+
+- [Form definitions](hmis-form-definitions.md) — the definition model, roles, and the status lifecycle
+- [Form resolution](hmis-form-resolution.md) — form rules, and which definition is used for a new or existing record
+- [HMIS form authoring](hmis-form-authoring.md) — the definition JSON, including `mapping`
+- [HMIS form seeding](hmis-form-seeding.md) — loading definitions from disk
+- [HMIS assessments](hmis-assessments.md) — what the assessment record types are
+- [HMIS auth policies](hmis-auth-policies.md) — the policies `SubmitFormAuthorizer` consults

--- a/docs/features/hmis/hmis-form-resolution.md
+++ b/docs/features/hmis/hmis-form-resolution.md
@@ -1,0 +1,117 @@
+# HMIS form resolution
+
+Several published form definitions can share a role, so "which form does the user get?" is a real question with a non-obvious answer. Resolution happens in three separate layers, and conflating them is the most common source of confusion in this subsystem:
+
+1. **Which definition applies** for new data entry in a project — decided by form rules.
+2. **Which definition is used** to view or edit an existing record — decided by what that record was collected with, mostly.
+3. **Which items inside the form** are shown — decided by per-item rules, evaluated partly on the server and partly in the browser.
+
+For the definition model and its statuses, see [Form definitions](hmis-form-definitions.md).
+
+## Form rules
+
+`Hmis::Form::Instance` (table `hmis_form_instances`), called a **Form Rule** in the UI, binds a form to a scope. A rule references a definition by `definition_identifier`, **not** by `id`, so publishing a new version changes which definition is live without any rule being touched.
+
+A rule's scope is expressed through these columns, all optional:
+
+| Column | Scope |
+| --- | --- |
+| `entity_type` / `entity_id` | A specific Project or Organization |
+| `project_type` | HUD project type |
+| `funder` / `other_funder` | HUD funding source |
+| `custom_service_type_id` / `custom_service_category_id` | Which service(s) a `SERVICE` form can collect |
+| `data_collected_about` | Which household members the form is collected for |
+
+A rule with none of the scope columns set is a **default** rule: it matches every project.
+
+Two flags matter. `system: true` rules are created by the seeding pipeline for HUD compliance and cannot be removed in the admin UI. `active: false` is how deletion works — rules are deactivated, not destroyed. Rules also cannot be edited in the UI; users deactivate one and create another.
+
+Validation enforces two role-specific requirements: a `SERVICE` rule must name a service type or category, and an `EXTERNAL_FORM` may have only one active rule, which must be Project-scoped.
+
+## Choosing a definition for new data entry
+
+`Hmis::Form::Definition.for_project` does this in three steps:
+
+1. Take all definitions for the role that are published, in the project's data source, and have at least one active rule.
+2. Of the rules pointing at those definitions, find the best match for this project.
+3. Return the published definition belonging to that rule's identifier.
+
+### Rule ranking
+
+`InstanceProjectMatch` ranks matches from most to least specific. `detect_best_instance_for_project` sorts by rank and takes the first, with a stable sort so ties resolve by scope order rather than at random.
+
+| Rank | Match | Meaning |
+| --- | --- | --- |
+| 0 | `project` | Rule names this project |
+| 1 | `organization` | Rule names this project's organization |
+| 2 | `project_type_and_funder` | Rule names both, and both match |
+| 3 | `project_type` | Rule names a project type only |
+| 4 | `project_funder` | Rule names a funder only |
+| 5 | `default` | Non-system rule with no scope |
+| 6 | `default_system` | System rule with no scope |
+
+System defaults rank last on purpose, so a community's own default rule beats the HUD-compliance one.
+
+Note that funder matching uses *all* of a project's funders, not just active ones, so a rule can still apply through a funder the project no longer has. That is a known wart, flagged in `instance_project_match.rb`.
+
+### Exclusive and inclusive roles
+
+The ranking above picks a single winner, which is right for some roles and wrong for others. The distinction is implemented in the GraphQL query layer, not on the model:
+
+- **Exclusive** roles (Project, Client, Enrollment, assessments): only the single best-matching form is used.
+- **Inclusive** roles (Services, custom assessments): every matching rule applies, so several forms are offered at once.
+
+`OCCURRENCE_POINT` is the exception that fits neither. Occurrence point forms behave inclusively but have no role-based exclusivity to fall back on, because there is no distinct role per occurrence point. The consequence is a configuration footgun: **two occurrence point rules that collect the same enrollment field will both apply, and the field appears twice on the enrollment dashboard** ([#6972](https://github.com/open-path/Green-River/issues/6972#issuecomment-2512299899)). This has not yet happened in a client environment, because non-super-admins cannot duplicate forms or map questions onto enrollment fields — both should be solved before those capabilities are opened up. `OccurrencePointFormCollection` also has a legacy path that surfaces retired HUD forms (move-in date, date of engagement, PATH status) when an enrollment has data for them but no active rule.
+
+### Enrollment-level matching
+
+For enrollment forms, a rule that matches the project must also match the enrollment. `InstanceEnrollmentMatch` evaluates the rule's `data_collected_about` against the enrollment: `ALL_CLIENTS`, `HOH_AND_ADULTS`, `HOH`, `ALL_VETERANS`, or `VETERAN_HOH`. Unset means `ALL_CLIENTS`.
+
+### Service forms
+
+Service forms resolve by service type through `Definition.for_service_type`, which prefers a rule naming the specific `custom_service_type` and falls back to one naming the `custom_service_category`. Because `SERVICE` is inclusive, a project can legitimately offer several service forms.
+
+### When nothing matches
+
+For system roles (Client, Project, Enrollment, and the rest), finding nothing is a fatal misconfiguration and raises. For optional roles like Current Living Situation, finding nothing simply means the feature is off in that project.
+
+The GraphQL resolvers go a step further: if no rule matches, `recordFormDefinition` and `serviceFormDefinition` fall back to *any* version-controlled published form for the role, on the reasoning that showing data with an imperfect form beats erroring. This is a deliberate safety net, and it also means a misconfigured project can look like it is working.
+
+## Choosing a definition for an existing record
+
+Every submitted form leaves a `Hmis::Form::FormProcessor` recording the exact definition used, which is what allows a record to be re-rendered in the shape it was collected in. What the UI does with that record varies by entry point.
+
+**Assessments upgrade on unlock.** `Assessment.upgradedDefinitionForEditing` returns the published version of the same identifier, but only when the original definition is retired and the assessment is not work-in-progress. The front-end views a submitted assessment with its original definition and swaps to the upgraded one when the user clicks Unlock — a client-side state change, not a server mutation — and submits against that newer id. So retiring an assessment form does not freeze old assessments. If no published version of the identifier exists, the upgrade resolves nil and the original definition is used for editing too.
+
+**Dialog-based record forms stay pinned.** Case notes, services, current living situations, and CE participations are edited in a dialog that passes the record's `formDefinitionId` back to `recordFormDefinition`, so they are always rendered and submitted with the definition they were collected with, retired or not, active rule or not. A retired record form therefore keeps its records editable in their original shape indefinitely.
+
+**Full-page record forms do not.** `EditRecord`, used for Client, Project, Organization, Inventory, and File, resolves by `role` and `projectId` and never passes the record's stored definition. Editing a Client can therefore submit against a newer published definition than the one the data was collected with. This looks unintentional rather than designed, and it is worth knowing before relying on "record forms are pinned" as a general rule.
+
+Nothing in the UI tells a user that the form in front of them is retired.
+
+## Item-level filtering
+
+A form can be resolved and still not show all of its questions. Two mechanisms do this, and they run in different places.
+
+**`rule` and `custom_rule` are evaluated on the server.** `DefinitionItemFilter` removes items when the definition is resolved, using the project and funders from `filter_context`. `rule` is HUD-derived and written by `set_hud_requirements`; `custom_rule` is installation-specific. When an item has both, either one passing is enough. With no project in context — the Client form outside a project, for instance — rules pass and nothing is filtered. The filtered result is what `FormDefinition.definition` returns; `raw_definition` is the unfiltered original.
+
+This has a sharp edge: **if every item is filtered out for a project, the GraphQL field is non-null and the query fails** with `Cannot return null for non-nullable field FormDefinition.definition` ([discussion](https://greenriver.slack.com/archives/C061SAW3LFJ/p1733158338135599)). Don't build a form whose questions are all conditioned away. Like the occurrence point issue, this is currently gated by non-super-admins being unable to author custom item rules.
+
+**`data_collected_about` on an item is evaluated in the browser.** For household assessments the server returns the full definition and the front-end strips items per client, in `applyDefinitionRulesForClient`. Do not expect the definition delivered over GraphQL to reflect it.
+
+### `data_collected_about` means two different things
+
+The same name is used at two layers, with different jobs:
+
+- **On a form rule**, it decides which household members the whole form is collected for. This is the `InstanceEnrollmentMatch` behavior above, and it is the only place `ALL_VETERANS` and `VETERAN_HOH` exist.
+- **On an item**, it is a HUD requirement about which clients a specific question applies to. `set_hud_requirements` reconciles the HUD requirement with whatever the form specifies and keeps the *less* strict of the two — so HUD does not simply win.
+
+`filter_context` is the ephemeral carrier for all of this: an attribute set on the definition by GraphQL resolvers, holding the project and sometimes an active date. It is easy to forget when exercising definitions outside of GraphQL, and it participates in the definition's cache key.
+
+## Related
+
+- [Form definitions](hmis-form-definitions.md) — the model, roles, and status lifecycle
+- [Form processing](hmis-form-processing.md) — what happens once a form is submitted
+- [Form seeding](hmis-form-seeding.md) — where system rules come from
+- [Form authoring](hmis-form-authoring.md) — the item properties referenced here
+- [HMIS assessments](hmis-assessments.md) — assessment record types and work-in-progress behavior

--- a/docs/features/hmis/hmis-form-seeding.md
+++ b/docs/features/hmis/hmis-form-seeding.md
@@ -11,22 +11,11 @@ This pipeline can also be manually invoked with task `rails driver:hmis:seed_def
 
 ### `Hmis::Form::Definition`
 
-A versioned form schema. The `definition` column holds a recursive JSON structure (based on FHIR Questionnaire) that describes inputs, labels, validation, and mappings to HMIS fields. Each definition has a stable `identifier`, a version, a role (`SERVICE`, `CLIENT`, `ENROLLMENT`, etc.), a status (`published`, `draft`, `retired`), and a reference to its `data_source` (to support isolated configuration for multi-HMIS). Definitions that originate from JSON files on disk have `managed_in_version_control: true` and are limited to a single published version per identifier.
-
-- Model: `drivers/hmis/app/models/hmis/form/definition.rb`
-- Table: `hmis_form_definitions`
+The versioned form schema itself (`drivers/hmis/app/models/hmis/form/definition.rb`, table `hmis_form_definitions`). Definitions loaded by this pipeline have `managed_in_version_control: true` and are limited to a single published version per identifier. See [Form definitions](hmis-form-definitions.md) for columns, roles, and the status lifecycle — noting that seeded forms bypass that lifecycle, since they are always published and overwritten in place on every run.
 
 ### `Hmis::Form::Instance`
 
-An applicability rule (“Form Rule” in the UI) that binds a form definition to a scope: project, organization, funder, project type, service category, or combinations. Instances control which projects and enrollments use a given form. Matching logic lives in `Hmis::Form::InstanceProjectMatch` and `Hmis::Form::InstanceEnrollmentMatch`.
-
-- **Exclusive** roles (e.g. Project, Client, Enrollment): the single best-matching instance wins.
-- **Inclusive** roles (e.g. Services, custom assessments): all matching instances apply.
-
-**System** instances (`system: true`, `active: true`) are created by `HudComplianceFormInstanceMaintainer` and cannot be removed through the admin UI. **Non-system** instances are user-created configuration.
-
-- Model: `drivers/hmis/app/models/hmis/form/instance.rb`
-- Table: `hmis_form_instances`
+An applicability rule ("Form Rule" in the UI) binding a definition to a scope such as a project, organization, funder, or project type (`drivers/hmis/app/models/hmis/form/instance.rb`, table `hmis_form_instances`). This pipeline creates the **system** instances (`system: true`) that HUD compliance requires; everything else is user-created configuration. See [Form resolution](hmis-form-resolution.md) for the scope columns, rule ranking, and how the app picks a form.
 
 ## Seeding pipeline
 
@@ -38,15 +27,11 @@ The task **`rails driver:hmis:seed_definitions`** ([`drivers/hmis/lib/tasks/setu
 
 3. `HudUtility2026`: Source of truth for which funder / project-type combinations require which forms for HUD compliance.
 
-## Version control vs Form Builder
+## Which forms belong here
 
-Forms can either be managed in version control (JSON files under `drivers/hmis/lib/form_data/`) or managed in the Form Builder in-app.
+Not every form should be seeded from JSON. That decision, and its consequences, are covered in [Form definitions — Version control or Form Builder?](hmis-form-definitions.md#version-control-or-form-builder). In short: HUD-compliant and application-critical forms belong in version control; customer-specific non-HUD forms belong in the Form Builder.
 
-**Prefer version control** for anything that collects **HUD fields** and must **stay HUD-compliant over time**—for example: Client form, HUD Service collection form, Current Living Situation, intake and exit assessments, Project form, and other definitions that ship under `default/` and are seeded as `managed_in_version_control`. In addition to HUD-related forms, any form that is essential to application function (aka it would crash without it) should be seeded from version control.
-
-**Do not manage in version control** forms that are **customer-specific and non-HUD**. Create and maintain those with the **Form Builder** admin tool instead. For example: custom assessments, service forms for **custom (non-HUD) services**, case note forms, **non-HUD** occurrence point forms, client details forms, and similar tenant-only content.
-
-**Patches and environment overrides** are for when you need a **customer-specific change to a HUD-compliant** form. For example: an extra field on the Client form, CLS, or HUD Service form; or extra sections/fields on HUD assessments. Those patches live under the client’s directory (see below) and are applied according to `ENV['CLIENT']` and the `form_data/` layout.
+**Patches and environment overrides** are for when you need a customer-specific change to a HUD-compliant form — an extra field on the Client form, CLS, or HUD Service form, or extra sections on a HUD assessment. Those patches live under the client's directory and are applied according to `ENV['CLIENT']` and the `form_data/` layout.
 
 ## Environment-specific overrides
 

--- a/drivers/hmis/app/graphql/mutations/publish_form_definition.rb
+++ b/drivers/hmis/app/graphql/mutations/publish_form_definition.rb
@@ -7,6 +7,9 @@
 # frozen_string_literal: true
 
 module Mutations
+  # Publishes a draft definition and retires the previously published version of the same identifier.
+  #
+  # @see docs/features/hmis/hmis-form-definitions.md#lifecycle For the full status lifecycle
   class PublishFormDefinition < CleanBaseMutation
     argument :id, ID, required: true
 

--- a/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
+++ b/drivers/hmis/app/graphql/types/hmis_schema/assessment.rb
@@ -89,6 +89,10 @@ module Types
     end
 
     # EXPENSIVE! Do not use in batch
+    #
+    # Assessments are unique in upgrading to the latest published form when edited. Record forms (case notes,
+    # services, CLS, etc) always edit with the definition on their form processor.
+    # @see docs/features/hmis/hmis-form-resolution.md#choosing-a-definition-for-an-existing-record
     def upgraded_definition_for_editing
       return if object.in_progress? # WIP assessments should use the original form for editing
       return unless form_processor.definition_id # tiny optimization: avoid calling 'definition' if it will invoke find_definition_for_role twice

--- a/drivers/hmis/app/models/hmis/form/definition.rb
+++ b/drivers/hmis/app/models/hmis/form/definition.rb
@@ -8,7 +8,8 @@
 
 # Versioned form definition. Contains a structured list of questions, information about how to render them, and information about available options and initial values. Nested recursive structure similar to FHIR Questionnaire.
 #
-# The canonical definitions are in json files under drivers/hmis/lib/form_data. When the json definitions changes, run the following command to freshen these db records
+# Forms managed in version control have their canonical definitions in json files under drivers/hmis/lib/form_data.
+# When the json definitions change, run the following command to freshen these db records
 #   rails driver:hmis:seed_definitions
 #
 # Table: hmis_form_definitions
@@ -19,12 +20,17 @@
 #   role
 #     the significance of this form within the system (INTAKE, EXIT, etc)
 #   status
-#     NOT IMPLEMENTED: aspirational support for draft status
+#     draft, published, or retired. At most one published version per identifier; publishing a draft retires
+#     the previous published version. Retired forms can still be submitted, so existing records stay editable.
 #   definition
 #     JSON field defines the inputs, labels, validation, and mapping to HMIS fields. A JSON-schema exists to validate
 #     the format of the definition
 #   title
 #     User-facing title of the form definition
+#
+# @see docs/features/hmis/hmis-form-definitions.md For roles and the status lifecycle
+# @see docs/features/hmis/hmis-form-resolution.md For how a definition is chosen, and how retired forms behave when editing existing records
+# @see docs/features/hmis/hmis-form-seeding.md For loading definitions from version-controlled JSON
 class Hmis::Form::Definition < ::GrdaWarehouseBase
   self.table_name = :hmis_form_definitions
   acts_as_paranoid

--- a/drivers/hmis/app/models/hmis/form/form_processor.rb
+++ b/drivers/hmis/app/models/hmis/form/form_processor.rb
@@ -9,6 +9,12 @@
 # Stores the actual data that was collected during an assessment. 1:1 with CustomAssessments.
 #   If the assessment is WIP: The data is stored exclusively as JSON blobs in the "values”/”hud_values" cols.
 #   If the assessment is non-WIP: The HUD data is stored in records (IncomeBenefit, HealthAndDv, etc) that are referenced by this form_processor directly. (health_and_dv_id etc)
+#
+# The `definition` reference is what lets a record be re-rendered later in the shape it was collected in,
+# and is why published and retired definitions cannot be deleted.
+#
+# @see docs/features/hmis/hmis-form-processing.md For the submission path and how values become records
+# @see docs/features/hmis/hmis-form-resolution.md For which definition is used when editing an existing record
 class Hmis::Form::FormProcessor < ::GrdaWarehouseBase
   self.table_name = :hmis_form_processors
   has_paper_trail

--- a/drivers/hmis/app/models/hmis/form/instance.rb
+++ b/drivers/hmis/app/models/hmis/form/instance.rb
@@ -36,6 +36,12 @@
 #   The application picks one form using InstanceProjectMatch/InstanceEnrollmentMatch ranking logic.
 # - INCLUSIVE roles (Services, Custom Assessments): ALL matching forms are displayed.
 #   If any Form Instance enables a form for a project (by project, type, org, etc.), it appears.
+#
+# Note that rules only select forms for *new* data entry. An existing record is edited with the definition
+# recorded on its form processor, which may be retired or no longer enabled by any rule.
+#
+# @see docs/features/hmis/hmis-form-resolution.md For rule ranking, exclusive vs inclusive roles, and item-level filtering
+# @see docs/features/hmis/hmis-form-definitions.md For form roles and the definition status lifecycle
 class Hmis::Form::Instance < ::GrdaWarehouseBase
   include Hmis::Concerns::HmisArelHelper
   self.table_name = :hmis_form_instances

--- a/drivers/hmis/lib/form_data/README.md
+++ b/drivers/hmis/lib/form_data/README.md
@@ -1,13 +1,10 @@
-# Form Configuration Guidelines
+# Form data
 
-Here are some form "gotchas" that we, as developers and Super-Admins of the config tool, should stay aware of when configuring client forms. This documentation lives in here near the code, for now, as opposed to in the Config Tool documentation, since our hope is to smooth these details over before handing off the related admin capabilities to users.
+JSON form definitions for "system-managed" forms, i.e. forms that are `managed_in_version_control`. Base definitions live in `default/`; sibling directories are per-client environment overrides selected by `ENV['CLIENT']`.
 
-- This directory contains form configuration for "system-managed" forms, aka forms that are `managed_in_version_control`.
-  - Don't put service forms or custom assessments in here. They should be managed in the Config Tool.
-- Don't create multiple Occurrence Point form instances that record the same data on enrollments. (Such as Move-in Date or Date of Engagement.)
-  - This would result in duplicate data showing on the enrollment dash, as described here: https://github.com/open-path/Green-River/issues/6972#issuecomment-2512299899
-  - This has not yet come up in a client environment. Non-Super Admins cannot yet Duplicate forms in the config tool, nor set data collection onto Enrollment Record fields (as opposed to Custom Data Elements). We should solve this before turning on either of those features outside of Super-Admin mode.
-  - This affects Occurrence Point Forms but not Data Collection Features because we don't have Form Roles for Occurrence Point Forms. With Data Collection Features, we would only ever return the best (most specific) form for that Role. (Maybe this points to a problem with the Occurrence Point Form implementation, and they should be transitioned to using Form Roles.)
-- Don't create a form definition where all questions are ruled out for a given project context by custom item rules.
-  - If we ever do this, and then enable the form in such a project, we see an error like this: [GraphQL GetEnrollmentDetails] message: "Cannot return null for non-nullable field FormDefinition.definition" [example](https://greenriver.slack.com/archives/C061SAW3LFJ/p1733158338135599)
-  - This has not yet come up in a client environment. Non-Super Admins cannot yet create custom form item rules in the Config Tool. We should solve this before enabling that functionality for more clients.
+Documentation for this directory lives in the feature docs, not here:
+
+- [Form seeding](../../../../docs/features/hmis/hmis-form-seeding.md) — how these files are loaded, and how fragments and patches resolve
+- [Form definitions](../../../../docs/features/hmis/hmis-form-definitions.md) — which forms belong in version control, and why seeded forms are always published and overwritten
+- [Form authoring](../../../../docs/features/hmis/hmis-form-authoring.md) — how to write the JSON
+- [Form resolution](../../../../docs/features/hmis/hmis-form-resolution.md) — configuration footguns, including duplicate occurrence point forms and forms whose items are all ruled out


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
Issue: https://github.com/open-path/Green-River/issues/5791


Adds feature documentation for the HMIS forms subsystem, split by the question each part answers. Existing form docs and the relevant models now link into these instead of re-explaining lifecycle and resolution.

This is **a lot** but I _think_ it's helpful to have, particularly as context for ai development.

Note: certain docs came up with a bunch of **"footguns"**; I kept the ones that seemed relevant- there could probably be follow-up tickets created for some of them, but I didn't do that here. There are LOTS of improvements we could make to this form system overall (especially processing; server-side validation; etc) -- I intentionally avoided getting into that. These docs describe _current_ behavior.

- `hmis-form-definitions.md` (new) — the `Hmis::Form::Definition` model, its columns and roles, and the draft/publish/retire lifecycle, including why seeded forms bypass it.
- `hmis-form-resolution.md` (new) — how form rules pick a definition for new data entry, which definition is used to edit an existing record, and item-level filtering.
- `hmis-form-authoring.md` (new) — how to write the definition JSON: `mapping`, conditional logic, pick lists, bounds, and the gotchas the schema and validator don't catch.
- `hmis-form-processing.md` (new) — what happens between submit and persisted records: the submission paths, `values` vs `hud_values`, container processors, validation phases, and footguns.
- `hmis-form-seeding.md` (updated) — trimmed to the seeding pipeline itself; the "version control vs Form Builder" decision guidance moved to the definitions doc, and the `form_data/` layout corrected.
- `hmis-assessments.md` (updated) — links out to the definitions and resolution docs for lifecycle and the assessment upgrade-on-unlock behavior.
- `drivers/hmis/lib/form_data/README.md` (updated) — reduced to a pointer at the feature docs, with its gotchas absorbed into them.



Unrelated: Fixes an undefined variable in `SubmitAssessment`. This path isn't used because the frontend doesn't call with validateOnly.


## Type of change
Documentation

## Checklist before requesting review
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I updated the documentation (or not applicable)
