### PR TITLE
[#9582] Fix source item display bug

### DIFF
--- a/app/controllers/source_data_controller.rb
+++ b/app/controllers/source_data_controller.rb
@@ -43,17 +43,9 @@ class SourceDataController < ApplicationController
   end
 
   private def show_imported_data
-    @importers = HmisCsvImporter::Importer::ImporterLog.without_phase_metrics.
-      where(data_source_id: @item.data_source_id).
-      order(created_at: :desc, id: :desc).
-      first(10)
-    return unless @importers.present?
+    @year = @item.most_recent_import_year
+    return unless @year
 
-    @importer = @importers.max_by do |importer|
-      [@item.imported_item_type(importer.id), importer&.created_at]
-    end
-
-    @year = @item.imported_item_type(@importer.id)
     @imported = @item.send("imported_items_#{@year}").order(importer_log_id: :desc).first
     @csv = @item.send("loaded_items_#{@year}").with_deleted.order(loader_id: :desc).first
   end

--- a/app/models/concerns/hmis_structure/base.rb
+++ b/app/models/concerns/hmis_structure/base.rb
@@ -16,19 +16,19 @@ module HmisStructure::Base
       where.not(pending_date_deleted: nil)
     end
 
-    # Find the spec year of this record's own most-recent surviving imported_items_YYYY
-    # or loaded_items_YYYY staging row -- regardless of which importer/loader run created
-    # it, and regardless of whether that run is still "recent." Returns nil if no staging
-    # row survives for this record in any known year.
-    #
-    # `find` short-circuits at the first matching year, so a record that's still current
-    # only ever costs an .exists? query against the newest year or two -- it does NOT scan
-    # every known spec year unless nothing survives anywhere.
+    # Spec year of this record's newest surviving importer or loader staging row, or nil
+    # when none survives in any registered year. Soft-deleted loader rows count: the loader
+    # table mirrors the CSV as received, so a row the HMIS marked deleted is still the CSV value.
     def most_recent_import_year
       known_years.find do |year|
         (respond_to?("imported_items_#{year}") && public_send("imported_items_#{year}").exists?) ||
-          (respond_to?("loaded_items_#{year}") && public_send("loaded_items_#{year}").exists?)
+          (respond_to?("loaded_items_#{year}") && surviving_loaded_items(year).exists?)
       end
+    end
+
+    private def surviving_loaded_items(year)
+      scope = public_send("loaded_items_#{year}")
+      scope.respond_to?(:with_deleted) ? scope.with_deleted : scope
     end
 
     private def known_years

--- a/app/models/concerns/hmis_structure/base.rb
+++ b/app/models/concerns/hmis_structure/base.rb
@@ -16,18 +16,23 @@ module HmisStructure::Base
       where.not(pending_date_deleted: nil)
     end
 
-    def imported_item_type(importer_log_id)
-      # NOTE: add additional years here as the spec changes, always the newest first for performance
-      return '2026' if imported_items_2026.where(importer_log_id: importer_log_id).exists?
-      return '2024' if imported_items_2024.where(importer_log_id: importer_log_id).exists?
-      # Handle classes that didn't exist previously
-      return '2024' if self.class.in?([GrdaWarehouse::Hud::HmisParticipation, GrdaWarehouse::Hud::CeParticipation])
+    # Find the spec year of this record's own most-recent surviving imported_items_YYYY
+    # or loaded_items_YYYY staging row -- regardless of which importer/loader run created
+    # it, and regardless of whether that run is still "recent." Returns nil if no staging
+    # row survives for this record in any known year.
+    #
+    # `find` short-circuits at the first matching year, so a record that's still current
+    # only ever costs an .exists? query against the newest year or two -- it does NOT scan
+    # every known spec year unless nothing survives anywhere.
+    def most_recent_import_year
+      known_years.find do |year|
+        (respond_to?("imported_items_#{year}") && public_send("imported_items_#{year}").exists?) ||
+          (respond_to?("loaded_items_#{year}") && public_send("loaded_items_#{year}").exists?)
+      end
+    end
 
-      return '2022' if imported_items_2022.where(importer_log_id: importer_log_id).exists?
-      # Handle classes that didn't exist previously
-      return '2022' if self.class.in?([GrdaWarehouse::Hud::YouthEducationStatus])
-
-      '2020'
+    private def known_years
+      Rails.application.config.hmis_data_lakes.keys.sort_by(&:to_i).reverse
     end
   end
 

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/expire_importers_job_spec.rb
@@ -25,6 +25,33 @@ RSpec.describe HmisCsvImporter::Cleanup::ExpireImportersJob, type: :model do
     HmisCsvImporter::Cleanup::ExpireImportersJob.new.perform(**default_options.merge(options))
   end
 
+  describe 'source-data display after expiration' do
+    let(:base_time) { DateTime.current.beginning_of_hour }
+
+    # Every import predates the cutoff, so only retain_item_count keeps anything.
+    before do
+      [7, 6, 5].each { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
+    end
+
+    it 'leaves the warehouse record resolving to its newest staging rows' do
+      organization = GrdaWarehouse::Hud::Organization.where(data_source_id: data_source.id).sole
+      newest_importer_row_id = organization.imported_items_2024.maximum(:id)
+      newest_loader_row_id = organization.loaded_items_2024.maximum(:id)
+
+      HmisCsvImporter::Cleanup::ExpireLoadersJob.new.perform(
+        model_name: 'HmisCsvTwentyTwentyFour::Loader::Organization',
+        dry_run: false,
+        retain_after_date: base_time + 10.years,
+        retain_item_count: 1,
+      )
+      run_job(retain_after_date: base_time + 10.years, retain_item_count: 1)
+
+      expect(organization.imported_items_2024.pluck(:id)).to eq([newest_importer_row_id])
+      expect(organization.loaded_items_2024.pluck(:id)).to eq([newest_loader_row_id])
+      expect(organization.most_recent_import_year).to eq('2024')
+    end
+  end
+
   describe '#models' do
     let(:job) { described_class.new }
 

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
@@ -120,6 +120,36 @@ RSpec.shared_examples 'HmisCsvImporter cleanup record expiration' do
       end
     end
 
+    describe 'never deletes the newest row for a key (rank-1 protection)' do
+      # All 5 imports are older than any plausible retention window.
+      before do
+        [7, 6, 5, 4, 3].each { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
+      end
+
+      it 'keeps the newest row for the key even when age-based protection protects nothing' do
+        ordered_ids = records.order(:id).pluck(:id)
+
+        # Pushing retain_after_date far into the future means every existing log predates the
+        # cutoff, so age-based protection (rule 2) protects nothing here -- everything depends
+        # on count-based protection (rule 1) alone. retain_item_count: 1 is the minimum count
+        # production ever configures (the rake task defaults to 5); this asserts that as long as
+        # count-based retention is enabled at all, the newest row for a key is always rank 1 and
+        # so can never exceed retain_item_count, regardless of how old it is. This is the
+        # invariant that makes it safe for cleanup to run against a data source where a record
+        # hasn't been re-imported in years: its current staging row is never swept.
+        #
+        # NOTE: this protection depends on retain_item_count being >= 1. retain_item_count: 0
+        # disables count-based protection entirely and deletes every row once it's older than
+        # retain_after_date, including the newest one -- that is a real, intentional behavior of
+        # the job, not a bug, but it means "the newest row is always safe" is only true under the
+        # production configuration (retain_item_count >= 1), not universally.
+        expect do
+          run_job(retain_after_date: base_time + 10.years, retain_item_count: 1)
+        end.to change { records.count }.from(5).to(1)
+        expect(records.pluck(:id)).to eq([ordered_ids.last])
+      end
+    end
+
     describe 'multi-data-source isolation' do
       let(:second_data_source) do
         GrdaWarehouse::DataSource.create(name: 'Other Source', short_name: 'OS', source_type: :sftp)

--- a/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
+++ b/drivers/hmis_csv_importer/spec/jobs/hmis_csv_importer/cleanup/shared.rb
@@ -120,36 +120,6 @@ RSpec.shared_examples 'HmisCsvImporter cleanup record expiration' do
       end
     end
 
-    describe 'never deletes the newest row for a key (rank-1 protection)' do
-      # All 5 imports are older than any plausible retention window.
-      before do
-        [7, 6, 5, 4, 3].each { |days_ago| import_csv_records(run_at: base_time - days_ago.days) }
-      end
-
-      it 'keeps the newest row for the key even when age-based protection protects nothing' do
-        ordered_ids = records.order(:id).pluck(:id)
-
-        # Pushing retain_after_date far into the future means every existing log predates the
-        # cutoff, so age-based protection (rule 2) protects nothing here -- everything depends
-        # on count-based protection (rule 1) alone. retain_item_count: 1 is the minimum count
-        # production ever configures (the rake task defaults to 5); this asserts that as long as
-        # count-based retention is enabled at all, the newest row for a key is always rank 1 and
-        # so can never exceed retain_item_count, regardless of how old it is. This is the
-        # invariant that makes it safe for cleanup to run against a data source where a record
-        # hasn't been re-imported in years: its current staging row is never swept.
-        #
-        # NOTE: this protection depends on retain_item_count being >= 1. retain_item_count: 0
-        # disables count-based protection entirely and deletes every row once it's older than
-        # retain_after_date, including the newest one -- that is a real, intentional behavior of
-        # the job, not a bug, but it means "the newest row is always safe" is only true under the
-        # production configuration (retain_item_count >= 1), not universally.
-        expect do
-          run_job(retain_after_date: base_time + 10.years, retain_item_count: 1)
-        end.to change { records.count }.from(5).to(1)
-        expect(records.pluck(:id)).to eq([ordered_ids.last])
-      end
-    end
-
     describe 'multi-data-source isolation' do
       let(:second_data_source) do
         GrdaWarehouse::DataSource.create(name: 'Other Source', short_name: 'OS', source_type: :sftp)

--- a/spec/models/concerns/hmis_structure/base_spec.rb
+++ b/spec/models/concerns/hmis_structure/base_spec.rb
@@ -1,0 +1,74 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe HmisStructure::Base, type: :model do
+  let(:data_source) { create(:source_data_source) }
+  let(:client) { create(:grda_warehouse_hud_client, data_source: data_source) }
+  let(:importer_log) { create(:hmis_csv_importer_log, data_source: data_source) }
+
+  def create_staging_row(klass, record: client, **attrs)
+    klass.create!(
+      PersonalID: record.PersonalID,
+      data_source_id: record.data_source_id,
+      **attrs,
+    )
+  end
+
+  def create_importer_row(klass, record: client, **attrs)
+    create_staging_row(
+      klass,
+      record: record,
+      importer_log_id: importer_log.id,
+      pre_processed_at: importer_log.created_at,
+      source_id: record.id,
+      source_type: record.class.name,
+      **attrs,
+    )
+  end
+
+  def create_loader_row(klass, **attrs)
+    create_staging_row(klass, loader_id: importer_log.id, loaded_at: importer_log.created_at, **attrs)
+  end
+
+  describe '#most_recent_import_year' do
+    it 'returns nil when no staging row survives in any registered year' do
+      expect(client.most_recent_import_year).to be_nil
+    end
+
+    it 'returns the newest registered year that has a surviving row' do
+      create_importer_row(HmisCsvTwentyTwentyFour::Importer::Client)
+      create_importer_row(HmisCsvTwentyTwentySix::Importer::Client)
+
+      expect(client.most_recent_import_year).to eq('2026')
+    end
+
+    it 'falls back to a loader row when no importer row survives' do
+      create_loader_row(HmisCsvTwentyTwentyFour::Loader::Client)
+
+      expect(client.most_recent_import_year).to eq('2024')
+    end
+
+    it 'ignores staging rows for the same HUD key in another data source' do
+      other_data_source = create(:source_data_source)
+      other_client = create(:grda_warehouse_hud_client, data_source: other_data_source, PersonalID: client.PersonalID)
+      create_importer_row(HmisCsvTwentyTwentyFour::Importer::Client)
+      create_importer_row(HmisCsvTwentyTwentySix::Importer::Client, record: other_client)
+
+      expect(client.most_recent_import_year).to eq('2024')
+    end
+
+    it 'returns nil for a model with no staging tables in older spec years' do
+      participation = create(:hud_hmis_participation, data_source: data_source)
+
+      expect(participation).not_to respond_to(:imported_items_2020)
+      expect(participation.most_recent_import_year).to be_nil
+    end
+  end
+end

--- a/spec/models/grda_warehouse/hud/project_source_data_spec.rb
+++ b/spec/models/grda_warehouse/hud/project_source_data_spec.rb
@@ -32,23 +32,6 @@ RSpec.describe GrdaWarehouse::Hud::Project, 'project CSV driver extensions' do
       expect(project.most_recent_import_year).to eq('2020')
       expect(project.imported_items_2020.where(importer_log_id: importer_log.id)).to exist
     end
-
-    it 'resolves most_recent_import_year regardless of how old the staging row\'s importer_log is' do
-      stale_importer_log = create(:hmis_csv_importer_log, data_source: data_source, created_at: 3.years.ago)
-      HmisCsvTwentyTwenty::Importer::Project.create!(
-        staging_attributes(project, stale_importer_log),
-      )
-
-      # most_recent_import_year takes no importer_log_id argument at all -- it must find the
-      # record's real staging row regardless of when the importer that created it ran.
-      expect(project.most_recent_import_year).to eq('2020')
-    end
-  end
-
-  describe 'most_recent_import_year' do
-    it 'returns nil when no staging rows survive for this record in any spec year' do
-      expect(project.most_recent_import_year).to be_nil
-    end
   end
 
   describe 'convert_to_aggregated!' do

--- a/spec/models/grda_warehouse/hud/project_source_data_spec.rb
+++ b/spec/models/grda_warehouse/hud/project_source_data_spec.rb
@@ -24,13 +24,30 @@ RSpec.describe GrdaWarehouse::Hud::Project, 'project CSV driver extensions' do
       end
     end
 
-    it 'resolves imported_item_type to 2020 when FY2020 staging rows exist' do
+    it 'resolves most_recent_import_year to 2020 when FY2020 staging rows exist' do
       HmisCsvTwentyTwenty::Importer::Project.create!(
         staging_attributes(project, importer_log),
       )
 
-      expect(project.imported_item_type(importer_log.id)).to eq('2020')
+      expect(project.most_recent_import_year).to eq('2020')
       expect(project.imported_items_2020.where(importer_log_id: importer_log.id)).to exist
+    end
+
+    it 'resolves most_recent_import_year regardless of how old the staging row\'s importer_log is' do
+      stale_importer_log = create(:hmis_csv_importer_log, data_source: data_source, created_at: 3.years.ago)
+      HmisCsvTwentyTwenty::Importer::Project.create!(
+        staging_attributes(project, stale_importer_log),
+      )
+
+      # most_recent_import_year takes no importer_log_id argument at all -- it must find the
+      # record's real staging row regardless of when the importer that created it ran.
+      expect(project.most_recent_import_year).to eq('2020')
+    end
+  end
+
+  describe 'most_recent_import_year' do
+    it 'returns nil when no staging rows survive for this record in any spec year' do
+      expect(project.most_recent_import_year).to be_nil
     end
   end
 

--- a/spec/requests/source_data_controller_spec.rb
+++ b/spec/requests/source_data_controller_spec.rb
@@ -57,9 +57,6 @@ RSpec.describe SourceDataController, type: :request do
         user_group.add(user)
         create(:access_control, role: role, collection: collection, user_group: user_group)
         collection.set_viewables({ data_sources: [data_source.id] })
-        allow(GrdaWarehouse::DataSource).to receive(:editable_by).with(user).and_return(
-          GrdaWarehouse::DataSource.all,
-        )
         sign_in user
       end
 
@@ -78,21 +75,31 @@ RSpec.describe SourceDataController, type: :request do
           expect(response).to render_template(:show)
         end
 
+        context 'for a record in a data source the user cannot edit' do
+          let(:other_data_source) { create(:authoritative_data_source) }
+          let!(:other_item) { create(:grda_warehouse_hud_client, data_source: other_data_source) }
+
+          it 'responds not found' do
+            get source_datum_path(id: other_item.id, type: 'Client')
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
         context 'with HMIS data source' do
           let(:hmis_data_source) { create(:hmis_data_source) }
           let!(:hmis_item) { create(:grda_warehouse_hud_client, data_source: hmis_data_source) }
 
           before do
-            user_group.add(user)
-            create(:access_control, role: role, collection: collection, user_group: user_group)
             collection.set_viewables({ data_sources: [hmis_data_source.id] })
           end
 
-          it 'assigns hmis variables' do
+          it 'marks the record HMIS-managed and shows no import columns' do
             get source_datum_path(id: hmis_item.id, type: 'Client')
             expect(assigns(:hmis)).to be true
             expect(assigns(:hmis_url)).to be_nil # user lacks access to view client in HMIS
-            expect(assigns(:importers)).to be_nil
+            expect(assigns(:imported)).to be false
+            expect(assigns(:csv)).to be false
+            expect(response.body).not_to include('CSV Value')
           end
 
           context 'and user has permission to view the client in OP HMIS' do
@@ -109,46 +116,83 @@ RSpec.describe SourceDataController, type: :request do
         end
 
         context 'with imported data source' do
-          it 'assigns falsy imported/csv values when no staging rows survive for this record' do
+          def create_importer_row(importer_log, klass: HmisCsvTwentyTwentyFour::Importer::Client)
+            klass.create!(
+              PersonalID: item.PersonalID,
+              data_source_id: item.data_source_id,
+              importer_log_id: importer_log.id,
+              pre_processed_at: importer_log.created_at,
+              source_id: item.id,
+              source_type: item.class.name,
+            )
+          end
+
+          def create_loader_row(importer_log, **attrs)
+            HmisCsvTwentyTwentyFour::Loader::Client.create!(
+              PersonalID: item.PersonalID,
+              data_source_id: item.data_source_id,
+              loader_id: importer_log.id,
+              loaded_at: importer_log.created_at,
+              **attrs,
+            )
+          end
+
+          it 'shows only the warehouse column when no staging rows survive for this record' do
             get source_datum_path(id: item.id, type: 'Client')
             expect(response).to have_http_status(:success)
             expect(assigns(:hmis)).to be_falsy
             expect(assigns(:imported)).to be_nil
             expect(assigns(:csv)).to be_nil
+            expect(response.body).not_to include('Post-Processed Value')
+            expect(response.body).not_to include('CSV Value')
           end
 
-          context 'and the record has a staging row from an importer run that is no longer "recent"' do
+          context 'and the record has a staging row from an importer run that is no longer recent' do
             let!(:stale_importer_log) { create(:hmis_csv_importer_log, data_source: data_source, created_at: 3.years.ago) }
-            let!(:staging_row) do
-              HmisCsvTwentyTwentyFour::Importer::Client.create!(
-                PersonalID: item.PersonalID,
-                data_source_id: item.data_source_id,
-                importer_log_id: stale_importer_log.id,
-                source_id: item.id,
-                source_type: item.class.name,
-                pre_processed_at: stale_importer_log.created_at,
-              )
-            end
-            let!(:loaded_row) do
-              HmisCsvTwentyTwentyFour::Loader::Client.create!(
-                PersonalID: item.PersonalID,
-                data_source_id: item.data_source_id,
-                loader_id: stale_importer_log.id,
-                loaded_at: stale_importer_log.created_at,
-              )
-            end
+            let!(:staging_row) { create_importer_row(stale_importer_log) }
+            let!(:loaded_row) { create_loader_row(stale_importer_log) }
             before do
-              # simulate a data source with many imports since this record's staging row was created,
-              # so the old "last 10 importer logs" window would have missed it entirely
+              # Ten newer runs that never re-imported this record.
               create_list(:hmis_csv_importer_log, 10, data_source: data_source)
             end
 
-            it 'still finds and assigns the record\'s real staging row, however old' do
+            it 'assigns the surviving staging rows and renders their columns' do
               get source_datum_path(id: item.id, type: 'Client')
               expect(assigns(:hmis)).to be_falsy
               expect(assigns(:year)).to eq('2024')
               expect(assigns(:imported)).to eq(staging_row)
               expect(assigns(:csv)).to eq(loaded_row)
+              expect(response.body).to include('Post-Processed Value')
+              expect(response.body).to include('CSV Value')
+            end
+          end
+
+          context 'and the record has staging rows from several importer runs in the same year' do
+            let!(:older_log) { create(:hmis_csv_importer_log, data_source: data_source, created_at: 2.days.ago) }
+            let!(:newer_log) { create(:hmis_csv_importer_log, data_source: data_source, created_at: 1.day.ago) }
+            let!(:older_importer_row) { create_importer_row(older_log) }
+            let!(:newer_importer_row) { create_importer_row(newer_log) }
+            let!(:older_loader_row) { create_loader_row(older_log) }
+            let!(:newer_loader_row) { create_loader_row(newer_log) }
+
+            it 'assigns the rows from the most recent run' do
+              get source_datum_path(id: item.id, type: 'Client')
+              expect(assigns(:imported)).to eq(newer_importer_row)
+              expect(assigns(:csv)).to eq(newer_loader_row)
+            end
+          end
+
+          context 'and only a soft-deleted loader row survives' do
+            let!(:importer_log) { create(:hmis_csv_importer_log, data_source: data_source) }
+            let!(:deleted_loader_row) { create_loader_row(importer_log, DateDeleted: 1.day.ago) }
+
+            it 'assigns the deleted CSV row and no post-processed row' do
+              get source_datum_path(id: item.id, type: 'Client')
+              expect(assigns(:year)).to eq('2024')
+              expect(assigns(:imported)).to be_nil
+              expect(assigns(:csv)).to eq(deleted_loader_row)
+              expect(response.body).to include('CSV Value')
+              expect(response.body).not_to include('Post-Processed Value')
             end
           end
         end

--- a/spec/requests/source_data_controller_spec.rb
+++ b/spec/requests/source_data_controller_spec.rb
@@ -109,13 +109,47 @@ RSpec.describe SourceDataController, type: :request do
         end
 
         context 'with imported data source' do
-          let!(:importer_log) { create(:hmis_csv_importer_log, data_source: data_source) }
-
-          it 'assigns importer variables' do
+          it 'assigns falsy imported/csv values when no staging rows survive for this record' do
             get source_datum_path(id: item.id, type: 'Client')
+            expect(response).to have_http_status(:success)
             expect(assigns(:hmis)).to be_falsy
-            expect(assigns(:importers)).to be_present
-            expect(assigns(:importer)).to eq(importer_log)
+            expect(assigns(:imported)).to be_nil
+            expect(assigns(:csv)).to be_nil
+          end
+
+          context 'and the record has a staging row from an importer run that is no longer "recent"' do
+            let!(:stale_importer_log) { create(:hmis_csv_importer_log, data_source: data_source, created_at: 3.years.ago) }
+            let!(:staging_row) do
+              HmisCsvTwentyTwentyFour::Importer::Client.create!(
+                PersonalID: item.PersonalID,
+                data_source_id: item.data_source_id,
+                importer_log_id: stale_importer_log.id,
+                source_id: item.id,
+                source_type: item.class.name,
+                pre_processed_at: stale_importer_log.created_at,
+              )
+            end
+            let!(:loaded_row) do
+              HmisCsvTwentyTwentyFour::Loader::Client.create!(
+                PersonalID: item.PersonalID,
+                data_source_id: item.data_source_id,
+                loader_id: stale_importer_log.id,
+                loaded_at: stale_importer_log.created_at,
+              )
+            end
+            before do
+              # simulate a data source with many imports since this record's staging row was created,
+              # so the old "last 10 importer logs" window would have missed it entirely
+              create_list(:hmis_csv_importer_log, 10, data_source: data_source)
+            end
+
+            it 'still finds and assigns the record\'s real staging row, however old' do
+              get source_datum_path(id: item.id, type: 'Client')
+              expect(assigns(:hmis)).to be_falsy
+              expect(assigns(:year)).to eq('2024')
+              expect(assigns(:imported)).to eq(staging_row)
+              expect(assigns(:csv)).to eq(loaded_row)
+            end
           end
         end
       end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Fixes a bug where if the source HMIS record hadn't been imported in the past 10 imports, the drill-down display (eg `/source_data/12345?type=Enrollment`) would not be able to find the importer and loader table display.
* Adds test coverage for the importer cleanup to prove the records should be retained.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

