### PR TITLE
chore:  9605  Move base images from Debian 12 (bookworm) to Debian 13 (trixie)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,7 @@ jobs:
   audit:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     permissions:
       contents: read

--- a/.github/workflows/build_images.yml
+++ b/.github/workflows/build_images.yml
@@ -41,7 +41,7 @@ jobs:
             hadolint_ignore: DL3008,DL3066
             trivy_skip_files: /app/config/key.pem,/app/docker/sftp/ssh_host_ed25519_key,/app/docker/sftp/ssh_host_rsa_key,/app/spec/fixtures/files/health/secret.key
             build-args: |
-              BUILD_TAG=3.4.9-slim-bookworm
+              BUILD_TAG=3.4.9-slim-trixie
               BUNDLER_VERSION=2.7.2
             tags: |
               type=sha,prefix=githash-

--- a/.github/workflows/container_setup/action.yml
+++ b/.github/workflows/container_setup/action.yml
@@ -47,7 +47,7 @@ runs:
 
         # Add PostgreSQL repository
         retry apt-get update
-        retry apt-get install -y software-properties-common curl ca-certificates lsb-release gnupg
+        retry apt-get install -y curl ca-certificates lsb-release gnupg
         # From https://www.postgresql.org/download/linux/debian/
         install -d /usr/share/postgresql-common/pgdg
         retry curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
@@ -89,7 +89,7 @@ runs:
           python3 \
           python3-pip \
           python3-venv \
-          software-properties-common \
+          shared-mime-info \
           unzip \
           zlib1g-dev \
           ${{ inputs.additional_packages }}

--- a/.github/workflows/eager_load_check.yml
+++ b/.github/workflows/eager_load_check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Eager Load Check
 
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     permissions:
       contents: read

--- a/.github/workflows/lsa_integration_test.yml
+++ b/.github/workflows/lsa_integration_test.yml
@@ -78,7 +78,7 @@ env:
 jobs:
   lsa_integration_test:
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     permissions:
       contents: read

--- a/.github/workflows/rails_tests.yml
+++ b/.github/workflows/rails_tests.yml
@@ -99,7 +99,7 @@ env:
 jobs:
   determine_matrix:
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     outputs:
       unit_matrix: ${{ steps.set-matrix.outputs.unit_matrix }}
@@ -148,7 +148,7 @@ jobs:
 
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     # Docker Hub image that the job executes in
     # $RUBY_VERSION
@@ -365,7 +365,7 @@ jobs:
       id-token: write
       pull-requests: read
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     services:
       postgres: *postgres
@@ -441,7 +441,7 @@ jobs:
       id-token: write
       pull-requests: read
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     services:
       postgres: *postgres

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
     name: Rubocop
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test_kit_fixpoints.yml
+++ b/.github/workflows/test_kit_fixpoints.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   rebuild_fixpoints:
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
     if: contains(github.event.head_commit.message, '[gh:rebuild_fixpoints]')
 
     permissions:

--- a/.github/workflows/todo_or_die.yml
+++ b/.github/workflows/todo_or_die.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   todo_or_die_check:
     runs-on: ubuntu-24.04
-    container: ruby:3.4.9-slim-bookworm
+    container: ruby:3.4.9-slim-trixie
     permissions:
       contents: read
       pull-requests: read

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -102,18 +102,18 @@ RUN apt-get update && apt-get upgrade -y \
   gpg \
   imagemagick \
   less \
-  libcurl4 \
+  libcurl4t64 \
   libcurl4-openssl-dev \
   libffi-dev \
   libfreetype-dev \
   libfreetype6 \
   libgeos-dev \
-  libglib2.0-0 \
+  libglib2.0-0t64 \
   libharfbuzz-dev \
   libheif1 \
   libicu-dev \
   libmagic-dev \
-  libmagic1 \
+  libmagic1t64 \
   libpq-dev \
   libsodium23 \
   libsodium-dev \
@@ -135,7 +135,8 @@ RUN apt-get update && apt-get upgrade -y \
   p7zip-full \
   packagekit \
   packagekit-tools \
-  policykit-1 \
+  pkexec \
+  polkitd \
   poppler-utils \
   postgresql-client \
   postgresql-server-dev-all \
@@ -143,7 +144,6 @@ RUN apt-get update && apt-get upgrade -y \
   pinentry-tty \
   shared-mime-info \
   ssh \
-  software-properties-common \
   tar \
   tini \
   tmux \
@@ -152,11 +152,6 @@ RUN apt-get update && apt-get upgrade -y \
   vim \
   zip \
   && rm -rf /var/lib/apt/lists/* \
-  && if [ "$(uname -m)" = "aarch64" ]; then \
-       ln -s /usr/lib/aarch64-linux-gnu/libproj.so /usr/lib/libproj.so.20; \
-     else \
-       ln -s /usr/lib/x86_64-linux-gnu/libproj.so /usr/lib/libproj.so.20; \
-     fi \
   && npm install -g yarn@1.22.22
 
 # Install custom pg_repack versions

--- a/docker/app/docker-compose.yaml
+++ b/docker/app/docker-compose.yaml
@@ -8,7 +8,7 @@ x-app: &app
     context: ../..
     dockerfile: docker/app/Dockerfile
     args:
-      BUILD_TAG: 3.4.9-slim-bookworm
+      BUILD_TAG: 3.4.9-slim-trixie
       USER_ID: ${USER_ID:-1001}
       GROUP_ID: ${GROUP_ID:-1001}
       #RUBY_VERSION: 3.4.9

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ x-app: &app
       BUNDLER_VERSION: "2.7.2"
       USER_ID: ${USER_ID:-1001}
       GROUP_ID: ${GROUP_ID:-1001}
-      BUILD_TAG: 3.4.9-slim-bookworm
+      BUILD_TAG: 3.4.9-slim-trixie
   environment: &env
     AWS_REGION: ${AWS_REGION:-us-east-1}
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
@@ -44,11 +44,11 @@ x-backend: &backend
   volumes:
     # NOTE: you may need to run `docker-compose run -u 0 shell chown -R app-user:app-user /bundle /app /node_modules` to fix permission issues
     - .:/app:cached
-    - rails_cache_bookworm:/app/tmp/cache
-    - bundle_bookworm:/bundle
+    - rails_cache_trixie:/app/tmp/cache
+    - bundle_trixie:/bundle
     - /usr/local/share/ca-certificates:/usr/local/share/ca-certificates
     - /etc/ssl/certs:/etc/ssl/certs
-    - node_modules_bookworm:/node_modules
+    - node_modules_trixie:/node_modules
 
 services:
   shell:
@@ -333,9 +333,9 @@ services:
       - traefik.http.routers.minio.middlewares=op_https
 
 volumes:
-  bundle_bookworm:
-  node_modules_bookworm:
-  rails_cache_bookworm:
+  bundle_trixie:
+  node_modules_trixie:
+  rails_cache_trixie:
   dbdata:
   dbdata_pg13:
   dbdata_pg16:

--- a/lib/development/scripts/update_worktree_env.rb
+++ b/lib/development/scripts/update_worktree_env.rb
@@ -158,9 +158,9 @@ rewrite(override) do |content|
   #    copies. The `hmis-warehouse_` prefix keeps them from colliding with other
   #    apps' identically-named volumes.
   {
-    'bundle_bookworm' => 'hmis-warehouse_bundle_bookworm',
-    'node_modules_bookworm' => 'hmis-warehouse_node_modules_bookworm',
-    'rails_cache_bookworm' => 'hmis-warehouse_rails_cache_bookworm',
+    'bundle_trixie' => 'hmis-warehouse_bundle_trixie',
+    'node_modules_trixie' => 'hmis-warehouse_node_modules_trixie',
+    'rails_cache_trixie' => 'hmis-warehouse_rails_cache_trixie',
   }.each do |vol, external_name|
     vidx = lines.index { |l| l.match?(/^ {2}#{Regexp.escape(vol)}:\s*$/) }
     next unless vidx


### PR DESCRIPTION
🤖 AI helped me write this

Bumps the app image and all nine CI containers to `ruby:3.4.9-slim-trixie`.

- `BUILD_TAG` and `container:` pins bumped across the compose files and workflows.
- Trixie package renames: `libcurl4`/`libglib2.0-0`/`libmagic1` gain the `t64` suffix,
  `policykit-1` splits into `polkitd` + `pkexec`, `software-properties-common` is gone
  (nothing used `add-apt-repository`).
- Dropped the `libproj.so.20` symlink — `rgeo-proj4` links `libproj.so.25`, which trixie
  ships and the loader finds on its own.
- Renamed the `bundle`/`node_modules`/`rails_cache` volumes to `*_trixie` so dev machines
  build fresh caches.

Out of scope: the pg13/pg16/pg17, keycloak, sftp, minio, and superset images, which track
their own upstream bases.

**Reviewers:** ImageMagick moves 6 → 7 as a side effect. `convert` still resolves via
`update-alternatives` and the IM7 `policy.xml` is no more restrictive, so `mini_magick`
should be fine — please exercise a client-file thumbnail anyway.

### Running locally

```
docker compose build --pull
docker compose run --rm shell cat /etc/os-release   # VERSION_CODENAME=trixie
docker compose run --rm shell bundle install        # volumes renamed, so these start empty
docker compose run --rm shell yarn install
```

Then reclaim the orphaned volumes:

```
docker volume ls | grep bookworm
docker volume rm <names listed above>
```

Worktree users: your `docker-compose.override.yml` may still name the `*_bookworm`
volumes. `update_worktree_env.rb` matches the new names only, so update it by hand before
creating new worktrees.
