### PR TITLE
[#7928] Add can_download_lsa_source_data permission for LSA source download

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -707,6 +707,12 @@ class Role < ApplicationRecord
         category: 'Reporting',
         sub_category: 'Exporting',
       },
+      can_download_lsa_source_data: {
+        description: 'Ability to download the source HMIS data attached to an LSA report run',
+        administrative: false,
+        category: 'Reporting',
+        sub_category: 'Exporting',
+      },
       can_export_anonymous_hmis_data: {
         description: 'Fake data exports for developers',
         administrative: true,

--- a/db/migrate/20260908120000_add_can_download_lsa_source_data_permission.rb
+++ b/db/migrate/20260908120000_add_can_download_lsa_source_data_permission.rb
@@ -1,0 +1,26 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+# Adds can_download_lsa_source_data (see Role.permissions_with_descriptions).
+#
+# can_export_hmis_data is what governed the LSA source download before this
+# permission existed, so those roles are backfilled to keep their access across the
+# deploy. Roles added after this runs default to false and must be granted the
+# permission deliberately.
+class AddCanDownloadLsaSourceDataPermission < ActiveRecord::Migration[7.2]
+  def up
+    Role.ensure_permissions_exist
+    Role.reset_column_information
+
+    Role.where(can_export_hmis_data: true).update_all(can_download_lsa_source_data: true)
+  end
+
+  def down
+    remove_column :roles, :can_download_lsa_source_data
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,6 +11,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: pg_repack; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_repack WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_repack; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_repack IS 'Reorganize tables in PostgreSQL databases with minimal locks';
+
+
+--
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -373,7 +387,6 @@ CREATE TABLE public.activity_logs (
 --
 
 CREATE SEQUENCE public.activity_logs_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -416,7 +429,6 @@ CREATE TABLE public.agencies_consent_limits (
 --
 
 CREATE SEQUENCE public.agencies_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -476,6 +488,90 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: building_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.building_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: building_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.building_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: buildings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.buildings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: client_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.client_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: client_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.client_notes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: client_opportunity_match_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.client_opportunity_match_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: client_opportunity_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.client_opportunity_matches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: client_service_history; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -502,6 +598,18 @@ CREATE TABLE public.client_service_history (
     housing_status_at_entry integer,
     housing_status_at_exit integer
 );
+
+
+--
+-- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.clients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -576,6 +684,18 @@ ALTER SEQUENCE public.collections_id_seq OWNED BY public.collections.id;
 
 
 --
+-- Name: configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.configs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: consent_limits; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -610,6 +730,54 @@ ALTER SEQUENCE public.consent_limits_id_seq OWNED BY public.consent_limits.id;
 
 
 --
+-- Name: contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: data_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.data_sources_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: date_of_birth_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.date_of_birth_quality_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: deidentified_clients_xlsxes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.deidentified_clients_xlsxes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -635,7 +803,6 @@ CREATE TABLE public.delayed_jobs (
 --
 
 CREATE SEQUENCE public.delayed_jobs_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -648,6 +815,114 @@ CREATE SEQUENCE public.delayed_jobs_id_seq
 --
 
 ALTER SEQUENCE public.delayed_jobs_id_seq OWNED BY public.delayed_jobs.id;
+
+
+--
+-- Name: disabling_conditions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.disabling_conditions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: discharge_statuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.discharge_statuses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: domestic_violence_survivors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.domestic_violence_survivors_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: entity_view_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.entity_view_permissions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ethnicities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ethnicities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: external_referrals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.external_referrals_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: file_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.file_tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: funding_source_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.funding_source_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: funding_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.funding_sources_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -727,6 +1002,42 @@ CREATE SEQUENCE public.glacier_vaults_id_seq
 --
 
 ALTER SEQUENCE public.glacier_vaults_id_seq OWNED BY public.glacier_vaults.id;
+
+
+--
+-- Name: has_developmental_disabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.has_developmental_disabilities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: has_hivaids_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.has_hivaids_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: has_mental_health_problems_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.has_mental_health_problems_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -940,10 +1251,10 @@ CREATE TABLE public.hmis_roles (
     can_manage_own_client_files boolean DEFAULT false NOT NULL,
     can_view_any_nonconfidential_client_files boolean DEFAULT false NOT NULL,
     can_view_any_confidential_client_files boolean DEFAULT false NOT NULL,
+    can_manage_client_files boolean DEFAULT false NOT NULL,
     can_audit_clients boolean DEFAULT false NOT NULL,
     can_delete_clients boolean DEFAULT false NOT NULL,
-    can_delete_assessments boolean DEFAULT false NOT NULL,
-    can_view_unenrolled_clients boolean DEFAULT false,
+    can_delete_assessments boolean DEFAULT false,
     can_manage_incoming_referrals boolean DEFAULT false,
     can_manage_outgoing_referrals boolean DEFAULT false,
     can_manage_denied_referrals boolean DEFAULT false,
@@ -957,8 +1268,8 @@ CREATE TABLE public.hmis_roles (
     can_view_limited_enrollment_details boolean DEFAULT false,
     can_impersonate_users boolean DEFAULT false,
     can_audit_users boolean DEFAULT false,
-    can_configure_data_collection boolean DEFAULT false,
     can_audit_enrollments boolean DEFAULT false,
+    can_configure_data_collection boolean DEFAULT false,
     can_manage_scan_cards boolean DEFAULT false,
     can_view_client_alerts boolean DEFAULT false,
     can_manage_client_alerts boolean DEFAULT false,
@@ -1136,6 +1447,30 @@ ALTER SEQUENCE public.hmis_user_groups_id_seq OWNED BY public.hmis_user_groups.i
 
 
 --
+-- Name: housing_attributes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.housing_attributes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: housing_media_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.housing_media_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: idp_service_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1154,7 +1489,6 @@ CREATE TABLE public.idp_service_configs (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    skip_ssl_verification boolean DEFAULT false NOT NULL,
     manage_users boolean DEFAULT true NOT NULL,
     browser_url character varying,
     account_client_id character varying
@@ -1178,6 +1512,18 @@ CREATE SEQUENCE public.idp_service_configs_id_seq
 --
 
 ALTER SEQUENCE public.idp_service_configs_id_seq OWNED BY public.idp_service_configs.id;
+
+
+--
+-- Name: imported_clients_csvs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.imported_clients_csvs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -1235,7 +1581,6 @@ CREATE TABLE public.letsencrypt_plugin_challenges (
 --
 
 CREATE SEQUENCE public.letsencrypt_plugin_challenges_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1267,7 +1612,6 @@ CREATE TABLE public.letsencrypt_plugin_settings (
 --
 
 CREATE SEQUENCE public.letsencrypt_plugin_settings_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1361,6 +1705,102 @@ ALTER SEQUENCE public.login_activities_id_seq OWNED BY public.login_activities.i
 
 
 --
+-- Name: match_census_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_census_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_decision_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_decision_reasons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_decisions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_mitigation_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_mitigation_reasons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_prioritizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_prioritizations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_progress_updates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_progress_updates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: match_routes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.match_routes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1383,7 +1823,6 @@ CREATE TABLE public.messages (
 --
 
 CREATE SEQUENCE public.messages_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1396,6 +1835,54 @@ CREATE SEQUENCE public.messages_id_seq
 --
 
 ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
+
+
+--
+-- Name: mitigation_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.mitigation_reasons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: name_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.name_quality_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: neighborhood_interests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.neighborhood_interests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: neighborhoods_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.neighborhoods_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -1427,6 +1914,42 @@ CREATE SEQUENCE public.nicknames_id_seq
 --
 
 ALTER SEQUENCE public.nicknames_id_seq OWNED BY public.nicknames.id;
+
+
+--
+-- Name: non_hmis_assessments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.non_hmis_assessments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: non_hmis_clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.non_hmis_clients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.notifications_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -1607,6 +2130,126 @@ ALTER SEQUENCE public.old_passwords_id_seq OWNED BY public.old_passwords.id;
 
 
 --
+-- Name: opportunities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.opportunities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: opportunity_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.opportunity_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: opportunity_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.opportunity_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: outreach_histories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.outreach_histories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: physical_disabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.physical_disabilities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: program_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.program_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: program_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.program_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.programs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: project_clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.project_clients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: project_programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.project_programs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: puma_scaling_login_demand; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -1641,6 +2284,78 @@ CREATE VIEW public.puma_scaling_login_demand AS
         )
  SELECT COALESCE(avg(distinct_logins), (0)::numeric) AS projected_unique_users
    FROM historical_window_counts;
+
+
+--
+-- Name: reissue_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reissue_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: rejected_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rejected_matches_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: report_definitions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.report_definitions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: report_files; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.report_files (
+    id bigint NOT NULL,
+    report_type character varying NOT NULL,
+    report_id bigint NOT NULL,
+    filename character varying NOT NULL,
+    content_type character varying NOT NULL,
+    byte_size integer,
+    file_type character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: report_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.report_files_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: report_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.report_files_id_seq OWNED BY public.report_files.id;
 
 
 --
@@ -1725,6 +2440,18 @@ ALTER SEQUENCE public.report_results_summaries_id_seq OWNED BY public.report_res
 
 
 --
+-- Name: reporting_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reporting_decisions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: reports; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1736,7 +2463,12 @@ CREATE TABLE public.reports (
     updated_at timestamp without time zone NOT NULL,
     weight integer DEFAULT 0 NOT NULL,
     report_results_summary_id bigint,
-    enabled boolean DEFAULT true NOT NULL
+    enabled boolean DEFAULT true NOT NULL,
+    number_files_expected integer DEFAULT 0,
+    report_data_removed boolean DEFAULT false,
+    stored_to_s3 boolean DEFAULT false,
+    data_cleaned boolean DEFAULT false,
+    archived_successfully boolean DEFAULT false
 );
 
 
@@ -1758,6 +2490,18 @@ CREATE SEQUENCE public.reports_id_seq
 --
 
 ALTER SEQUENCE public.reports_id_seq OWNED BY public.reports.id;
+
+
+--
+-- Name: requirements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.requirements_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -1885,8 +2629,9 @@ CREATE TABLE public.roles (
     can_search_own_clients boolean DEFAULT false,
     can_view_confidential_project_names boolean DEFAULT false,
     can_report_on_confidential_projects boolean DEFAULT false,
-    can_view_chronic_tab boolean DEFAULT false,
     can_edit_assigned_project_groups boolean DEFAULT false,
+    can_view_chronic_tab boolean DEFAULT false,
+    can_view_confidential_enrollment_details boolean DEFAULT false,
     can_configure_cohorts boolean DEFAULT false,
     can_add_cohort_clients boolean DEFAULT false,
     can_manage_cohort_data boolean DEFAULT false,
@@ -1897,11 +2642,11 @@ CREATE TABLE public.roles (
     can_view_deleted_cohort_clients boolean DEFAULT false,
     can_view_cohort_client_changes_report boolean DEFAULT false,
     can_manage_inbound_api_configurations boolean DEFAULT false,
+    system boolean DEFAULT false NOT NULL,
     can_view_client_enrollments_with_roi boolean DEFAULT false,
     can_search_clients_with_roi boolean DEFAULT false,
     can_see_confidential_files boolean DEFAULT false,
     can_edit_theme boolean DEFAULT false,
-    system boolean DEFAULT false NOT NULL,
     can_edit_collections boolean DEFAULT false,
     can_publish_reports boolean DEFAULT false,
     deleted_at timestamp without time zone,
@@ -1911,7 +2656,8 @@ CREATE TABLE public.roles (
     can_view_project_locations boolean DEFAULT false,
     can_view_supplemental_client_data boolean DEFAULT false,
     can_edit_cohort_columns boolean DEFAULT false,
-    can_receive_cohort_note_notifications boolean DEFAULT false
+    can_receive_cohort_note_notifications boolean DEFAULT false,
+    can_download_lsa_source_data boolean DEFAULT false
 );
 
 
@@ -1920,7 +2666,6 @@ CREATE TABLE public.roles (
 --
 
 CREATE SEQUENCE public.roles_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1936,12 +2681,60 @@ ALTER SEQUENCE public.roles_id_seq OWNED BY public.roles.id;
 
 
 --
+-- Name: rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.rules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
+
+
+--
+-- Name: service_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.service_rules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: shelter_histories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.shelter_histories_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -1979,6 +2772,90 @@ CREATE SEQUENCE public.similarity_metrics_id_seq
 --
 
 ALTER SEQUENCE public.similarity_metrics_id_seq OWNED BY public.similarity_metrics.id;
+
+
+--
+-- Name: social_security_number_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.social_security_number_quality_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: stalled_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.stalled_responses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sub_program_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sub_program_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sub_programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sub_programs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: subgrantee_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.subgrantee_contacts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: subgrantee_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.subgrantee_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: subgrantees_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.subgrantees_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -2033,7 +2910,6 @@ CREATE TABLE public.tags (
 --
 
 CREATE SEQUENCE public.tags_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2187,6 +3063,18 @@ ALTER SEQUENCE public.two_factors_memorized_devices_id_seq OWNED BY public.two_f
 
 
 --
+-- Name: unavailable_as_candidate_fors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.unavailable_as_candidate_fors_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: unique_names; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2215,6 +3103,18 @@ CREATE SEQUENCE public.unique_names_id_seq
 --
 
 ALTER SEQUENCE public.unique_names_id_seq OWNED BY public.unique_names.id;
+
+
+--
+-- Name: units_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.units_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -2382,7 +3282,6 @@ CREATE TABLE public.user_roles (
 --
 
 CREATE SEQUENCE public.user_roles_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2487,7 +3386,6 @@ COMMENT ON COLUMN public.users.custom_session_invalidator IS 'Changing the value
 --
 
 CREATE SEQUENCE public.users_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2519,7 +3417,8 @@ CREATE TABLE public.versions (
     request_id character varying,
     object_changes text,
     referenced_user_id bigint,
-    referenced_entity_name character varying
+    referenced_entity_name character varying,
+    true_user_id bigint
 );
 
 
@@ -2528,7 +3427,6 @@ CREATE TABLE public.versions (
 --
 
 CREATE SEQUENCE public.versions_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2541,6 +3439,30 @@ CREATE SEQUENCE public.versions_id_seq
 --
 
 ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
+
+
+--
+-- Name: veteran_statuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.veteran_statuses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vouchers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.vouchers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -2575,6 +3497,18 @@ CREATE SEQUENCE public.warehouse_alerts_id_seq
 --
 
 ALTER SEQUENCE public.warehouse_alerts_id_seq OWNED BY public.warehouse_alerts.id;
+
+
+--
+-- Name: weighting_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.weighting_rules_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
 
 
 --
@@ -2834,6 +3768,13 @@ ALTER TABLE ONLY public.oauth_identities ALTER COLUMN id SET DEFAULT nextval('pu
 --
 
 ALTER TABLE ONLY public.old_passwords ALTER COLUMN id SET DEFAULT nextval('public.old_passwords_id_seq'::regclass);
+
+
+--
+-- Name: report_files id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report_files ALTER COLUMN id SET DEFAULT nextval('public.report_files_id_seq'::regclass);
 
 
 --
@@ -3281,6 +4222,14 @@ ALTER TABLE ONLY public.old_passwords
 
 
 --
+-- Name: report_files report_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report_files
+    ADD CONSTRAINT report_files_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: report_results report_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3466,7 +4415,7 @@ CREATE UNIQUE INDEX idx_oauth_on_provider_and_uid ON public.oauth_identities USI
 -- Name: idx_on_connector_user_id_connector_id_2c69cda92c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_on_connector_user_id_connector_id_2c69cda92c ON public.user_authentication_sources USING btree (connector_user_id, connector_id) WHERE (deleted_at IS NULL);
+CREATE UNIQUE INDEX idx_on_connector_user_id_connector_id_2c69cda92c ON public.user_authentication_sources USING btree (connector_user_id, connector_id);
 
 
 --
@@ -3862,6 +4811,27 @@ CREATE INDEX index_password_archivable ON public.old_passwords USING btree (pass
 
 
 --
+-- Name: index_report_files_on_filename; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_report_files_on_filename ON public.report_files USING btree (filename);
+
+
+--
+-- Name: index_report_files_on_report; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_report_files_on_report ON public.report_files USING btree (report_type, report_id);
+
+
+--
+-- Name: index_report_files_on_report_type_and_report_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_report_files_on_report_type_and_report_id ON public.report_files USING btree (report_type, report_id);
+
+
+--
 -- Name: index_report_results_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4006,6 +4976,13 @@ CREATE INDEX index_uploads_on_deleted_at ON public.uploads USING btree (deleted_
 --
 
 CREATE UNIQUE INDEX index_user_auth_sources_on_user_connector_live ON public.user_authentication_sources USING btree (user_id, connector_id) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_user_authentication_sources_on_deleted_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_authentication_sources_on_deleted_at ON public.user_authentication_sources USING btree (deleted_at);
 
 
 --
@@ -4244,6 +5221,8 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260908120000'),
+('20260904120000'),
 ('20260827151000'),
 ('20260827150000'),
 ('20260820120000'),
@@ -4252,7 +5231,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260804120000'),
 ('20260803120000'),
 ('20260724120000'),
-('20260720000000'),
 ('20260715120000'),
 ('20260623120001'),
 ('20260620000000'),
@@ -4260,6 +5238,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260611120000'),
 ('20260520213800'),
 ('20260207120000'),
+('20260102144558'),
+('20260102144557'),
+('20251224185104'),
 ('20251215205826'),
 ('20251120143000'),
 ('20251106020333'),
@@ -4312,6 +5293,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240401041826'),
 ('20240401041825'),
 ('20240401041824'),
+('20240326000000'),
 ('20240313162012'),
 ('20240313161801'),
 ('20240311135958'),
@@ -4363,11 +5345,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230429112954'),
 ('20230429112926'),
 ('20230429102609'),
-('20230426170051'),
 ('20230424123118'),
 ('20230420195221'),
 ('20230418170053'),
 ('20230412142430'),
+('20230330182609'),
 ('20230330161305'),
 ('20230328150855'),
 ('20230322204908'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11,20 +11,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: pg_repack; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS pg_repack WITH SCHEMA public;
-
-
---
--- Name: EXTENSION pg_repack; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION pg_repack IS 'Reorganize tables in PostgreSQL databases with minimal locks';
-
-
---
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -387,6 +373,7 @@ CREATE TABLE public.activity_logs (
 --
 
 CREATE SEQUENCE public.activity_logs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -429,6 +416,7 @@ CREATE TABLE public.agencies_consent_limits (
 --
 
 CREATE SEQUENCE public.agencies_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -488,90 +476,6 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
--- Name: building_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.building_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: building_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.building_services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: buildings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.buildings_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: client_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.client_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: client_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.client_notes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: client_opportunity_match_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.client_opportunity_match_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: client_opportunity_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.client_opportunity_matches_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: client_service_history; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -598,18 +502,6 @@ CREATE TABLE public.client_service_history (
     housing_status_at_entry integer,
     housing_status_at_exit integer
 );
-
-
---
--- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.clients_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -684,18 +576,6 @@ ALTER SEQUENCE public.collections_id_seq OWNED BY public.collections.id;
 
 
 --
--- Name: configs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.configs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: consent_limits; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -730,54 +610,6 @@ ALTER SEQUENCE public.consent_limits_id_seq OWNED BY public.consent_limits.id;
 
 
 --
--- Name: contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: data_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.data_sources_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: date_of_birth_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.date_of_birth_quality_codes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: deidentified_clients_xlsxes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.deidentified_clients_xlsxes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: delayed_jobs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -803,6 +635,7 @@ CREATE TABLE public.delayed_jobs (
 --
 
 CREATE SEQUENCE public.delayed_jobs_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -815,114 +648,6 @@ CREATE SEQUENCE public.delayed_jobs_id_seq
 --
 
 ALTER SEQUENCE public.delayed_jobs_id_seq OWNED BY public.delayed_jobs.id;
-
-
---
--- Name: disabling_conditions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.disabling_conditions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: discharge_statuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.discharge_statuses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: domestic_violence_survivors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.domestic_violence_survivors_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: entity_view_permissions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.entity_view_permissions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: ethnicities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.ethnicities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: external_referrals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.external_referrals_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: file_tags_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.file_tags_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: funding_source_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.funding_source_services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: funding_sources_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.funding_sources_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -1002,42 +727,6 @@ CREATE SEQUENCE public.glacier_vaults_id_seq
 --
 
 ALTER SEQUENCE public.glacier_vaults_id_seq OWNED BY public.glacier_vaults.id;
-
-
---
--- Name: has_developmental_disabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.has_developmental_disabilities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: has_hivaids_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.has_hivaids_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: has_mental_health_problems_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.has_mental_health_problems_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -1251,10 +940,10 @@ CREATE TABLE public.hmis_roles (
     can_manage_own_client_files boolean DEFAULT false NOT NULL,
     can_view_any_nonconfidential_client_files boolean DEFAULT false NOT NULL,
     can_view_any_confidential_client_files boolean DEFAULT false NOT NULL,
-    can_manage_client_files boolean DEFAULT false NOT NULL,
     can_audit_clients boolean DEFAULT false NOT NULL,
     can_delete_clients boolean DEFAULT false NOT NULL,
-    can_delete_assessments boolean DEFAULT false,
+    can_delete_assessments boolean DEFAULT false NOT NULL,
+    can_view_unenrolled_clients boolean DEFAULT false,
     can_manage_incoming_referrals boolean DEFAULT false,
     can_manage_outgoing_referrals boolean DEFAULT false,
     can_manage_denied_referrals boolean DEFAULT false,
@@ -1268,8 +957,8 @@ CREATE TABLE public.hmis_roles (
     can_view_limited_enrollment_details boolean DEFAULT false,
     can_impersonate_users boolean DEFAULT false,
     can_audit_users boolean DEFAULT false,
-    can_audit_enrollments boolean DEFAULT false,
     can_configure_data_collection boolean DEFAULT false,
+    can_audit_enrollments boolean DEFAULT false,
     can_manage_scan_cards boolean DEFAULT false,
     can_view_client_alerts boolean DEFAULT false,
     can_manage_client_alerts boolean DEFAULT false,
@@ -1447,30 +1136,6 @@ ALTER SEQUENCE public.hmis_user_groups_id_seq OWNED BY public.hmis_user_groups.i
 
 
 --
--- Name: housing_attributes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.housing_attributes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: housing_media_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.housing_media_links_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: idp_service_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1489,6 +1154,7 @@ CREATE TABLE public.idp_service_configs (
     deleted_at timestamp(6) without time zone,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
+    skip_ssl_verification boolean DEFAULT false NOT NULL,
     manage_users boolean DEFAULT true NOT NULL,
     browser_url character varying,
     account_client_id character varying
@@ -1512,18 +1178,6 @@ CREATE SEQUENCE public.idp_service_configs_id_seq
 --
 
 ALTER SEQUENCE public.idp_service_configs_id_seq OWNED BY public.idp_service_configs.id;
-
-
---
--- Name: imported_clients_csvs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.imported_clients_csvs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -1581,6 +1235,7 @@ CREATE TABLE public.letsencrypt_plugin_challenges (
 --
 
 CREATE SEQUENCE public.letsencrypt_plugin_challenges_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1612,6 +1267,7 @@ CREATE TABLE public.letsencrypt_plugin_settings (
 --
 
 CREATE SEQUENCE public.letsencrypt_plugin_settings_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1705,102 +1361,6 @@ ALTER SEQUENCE public.login_activities_id_seq OWNED BY public.login_activities.i
 
 
 --
--- Name: match_census_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_census_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_decision_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_decision_reasons_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_decisions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_events_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_mitigation_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_mitigation_reasons_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_prioritizations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_prioritizations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_progress_updates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_progress_updates_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: match_routes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.match_routes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1823,6 +1383,7 @@ CREATE TABLE public.messages (
 --
 
 CREATE SEQUENCE public.messages_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1835,54 +1396,6 @@ CREATE SEQUENCE public.messages_id_seq
 --
 
 ALTER SEQUENCE public.messages_id_seq OWNED BY public.messages.id;
-
-
---
--- Name: mitigation_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.mitigation_reasons_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: name_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.name_quality_codes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: neighborhood_interests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.neighborhood_interests_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: neighborhoods_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.neighborhoods_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -1914,42 +1427,6 @@ CREATE SEQUENCE public.nicknames_id_seq
 --
 
 ALTER SEQUENCE public.nicknames_id_seq OWNED BY public.nicknames.id;
-
-
---
--- Name: non_hmis_assessments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.non_hmis_assessments_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: non_hmis_clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.non_hmis_clients_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: notifications_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.notifications_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -2130,126 +1607,6 @@ ALTER SEQUENCE public.old_passwords_id_seq OWNED BY public.old_passwords.id;
 
 
 --
--- Name: opportunities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.opportunities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: opportunity_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.opportunity_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: opportunity_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.opportunity_properties_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: outreach_histories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.outreach_histories_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: physical_disabilities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.physical_disabilities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: program_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.program_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: program_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.program_services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.programs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: project_clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.project_clients_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: project_programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.project_programs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: puma_scaling_login_demand; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -2284,78 +1641,6 @@ CREATE VIEW public.puma_scaling_login_demand AS
         )
  SELECT COALESCE(avg(distinct_logins), (0)::numeric) AS projected_unique_users
    FROM historical_window_counts;
-
-
---
--- Name: reissue_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.reissue_requests_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: rejected_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.rejected_matches_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: report_definitions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.report_definitions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: report_files; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.report_files (
-    id bigint NOT NULL,
-    report_type character varying NOT NULL,
-    report_id bigint NOT NULL,
-    filename character varying NOT NULL,
-    content_type character varying NOT NULL,
-    byte_size integer,
-    file_type character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: report_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.report_files_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: report_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.report_files_id_seq OWNED BY public.report_files.id;
 
 
 --
@@ -2440,18 +1725,6 @@ ALTER SEQUENCE public.report_results_summaries_id_seq OWNED BY public.report_res
 
 
 --
--- Name: reporting_decisions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.reporting_decisions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: reports; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2463,12 +1736,7 @@ CREATE TABLE public.reports (
     updated_at timestamp without time zone NOT NULL,
     weight integer DEFAULT 0 NOT NULL,
     report_results_summary_id bigint,
-    enabled boolean DEFAULT true NOT NULL,
-    number_files_expected integer DEFAULT 0,
-    report_data_removed boolean DEFAULT false,
-    stored_to_s3 boolean DEFAULT false,
-    data_cleaned boolean DEFAULT false,
-    archived_successfully boolean DEFAULT false
+    enabled boolean DEFAULT true NOT NULL
 );
 
 
@@ -2490,18 +1758,6 @@ CREATE SEQUENCE public.reports_id_seq
 --
 
 ALTER SEQUENCE public.reports_id_seq OWNED BY public.reports.id;
-
-
---
--- Name: requirements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.requirements_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -2629,9 +1885,8 @@ CREATE TABLE public.roles (
     can_search_own_clients boolean DEFAULT false,
     can_view_confidential_project_names boolean DEFAULT false,
     can_report_on_confidential_projects boolean DEFAULT false,
-    can_edit_assigned_project_groups boolean DEFAULT false,
     can_view_chronic_tab boolean DEFAULT false,
-    can_view_confidential_enrollment_details boolean DEFAULT false,
+    can_edit_assigned_project_groups boolean DEFAULT false,
     can_configure_cohorts boolean DEFAULT false,
     can_add_cohort_clients boolean DEFAULT false,
     can_manage_cohort_data boolean DEFAULT false,
@@ -2642,11 +1897,11 @@ CREATE TABLE public.roles (
     can_view_deleted_cohort_clients boolean DEFAULT false,
     can_view_cohort_client_changes_report boolean DEFAULT false,
     can_manage_inbound_api_configurations boolean DEFAULT false,
-    system boolean DEFAULT false NOT NULL,
     can_view_client_enrollments_with_roi boolean DEFAULT false,
     can_search_clients_with_roi boolean DEFAULT false,
     can_see_confidential_files boolean DEFAULT false,
     can_edit_theme boolean DEFAULT false,
+    system boolean DEFAULT false NOT NULL,
     can_edit_collections boolean DEFAULT false,
     can_publish_reports boolean DEFAULT false,
     deleted_at timestamp without time zone,
@@ -2666,6 +1921,7 @@ CREATE TABLE public.roles (
 --
 
 CREATE SEQUENCE public.roles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2681,60 +1937,12 @@ ALTER SEQUENCE public.roles_id_seq OWNED BY public.roles.id;
 
 
 --
--- Name: rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.rules_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
-
-
---
--- Name: service_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.service_rules_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: shelter_histories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.shelter_histories_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -2772,90 +1980,6 @@ CREATE SEQUENCE public.similarity_metrics_id_seq
 --
 
 ALTER SEQUENCE public.similarity_metrics_id_seq OWNED BY public.similarity_metrics.id;
-
-
---
--- Name: social_security_number_quality_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.social_security_number_quality_codes_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: stalled_responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.stalled_responses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sub_program_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sub_program_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sub_programs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sub_programs_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: subgrantee_contacts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.subgrantee_contacts_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: subgrantee_services_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.subgrantee_services_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: subgrantees_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.subgrantees_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -2910,6 +2034,7 @@ CREATE TABLE public.tags (
 --
 
 CREATE SEQUENCE public.tags_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3063,18 +2188,6 @@ ALTER SEQUENCE public.two_factors_memorized_devices_id_seq OWNED BY public.two_f
 
 
 --
--- Name: unavailable_as_candidate_fors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.unavailable_as_candidate_fors_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
 -- Name: unique_names; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3103,18 +2216,6 @@ CREATE SEQUENCE public.unique_names_id_seq
 --
 
 ALTER SEQUENCE public.unique_names_id_seq OWNED BY public.unique_names.id;
-
-
---
--- Name: units_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.units_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -3282,6 +2383,7 @@ CREATE TABLE public.user_roles (
 --
 
 CREATE SEQUENCE public.user_roles_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3386,6 +2488,7 @@ COMMENT ON COLUMN public.users.custom_session_invalidator IS 'Changing the value
 --
 
 CREATE SEQUENCE public.users_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3417,8 +2520,7 @@ CREATE TABLE public.versions (
     request_id character varying,
     object_changes text,
     referenced_user_id bigint,
-    referenced_entity_name character varying,
-    true_user_id bigint
+    referenced_entity_name character varying
 );
 
 
@@ -3427,6 +2529,7 @@ CREATE TABLE public.versions (
 --
 
 CREATE SEQUENCE public.versions_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3439,30 +2542,6 @@ CREATE SEQUENCE public.versions_id_seq
 --
 
 ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
-
-
---
--- Name: veteran_statuses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.veteran_statuses_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: vouchers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.vouchers_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -3497,18 +2576,6 @@ CREATE SEQUENCE public.warehouse_alerts_id_seq
 --
 
 ALTER SEQUENCE public.warehouse_alerts_id_seq OWNED BY public.warehouse_alerts.id;
-
-
---
--- Name: weighting_rules_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.weighting_rules_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
 
 
 --
@@ -3768,13 +2835,6 @@ ALTER TABLE ONLY public.oauth_identities ALTER COLUMN id SET DEFAULT nextval('pu
 --
 
 ALTER TABLE ONLY public.old_passwords ALTER COLUMN id SET DEFAULT nextval('public.old_passwords_id_seq'::regclass);
-
-
---
--- Name: report_files id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.report_files ALTER COLUMN id SET DEFAULT nextval('public.report_files_id_seq'::regclass);
 
 
 --
@@ -4222,14 +3282,6 @@ ALTER TABLE ONLY public.old_passwords
 
 
 --
--- Name: report_files report_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.report_files
-    ADD CONSTRAINT report_files_pkey PRIMARY KEY (id);
-
-
---
 -- Name: report_results report_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4415,7 +3467,7 @@ CREATE UNIQUE INDEX idx_oauth_on_provider_and_uid ON public.oauth_identities USI
 -- Name: idx_on_connector_user_id_connector_id_2c69cda92c; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_on_connector_user_id_connector_id_2c69cda92c ON public.user_authentication_sources USING btree (connector_user_id, connector_id);
+CREATE UNIQUE INDEX idx_on_connector_user_id_connector_id_2c69cda92c ON public.user_authentication_sources USING btree (connector_user_id, connector_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -4811,27 +3863,6 @@ CREATE INDEX index_password_archivable ON public.old_passwords USING btree (pass
 
 
 --
--- Name: index_report_files_on_filename; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_report_files_on_filename ON public.report_files USING btree (filename);
-
-
---
--- Name: index_report_files_on_report; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_report_files_on_report ON public.report_files USING btree (report_type, report_id);
-
-
---
--- Name: index_report_files_on_report_type_and_report_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_report_files_on_report_type_and_report_id ON public.report_files USING btree (report_type, report_id);
-
-
---
 -- Name: index_report_results_on_deleted_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4976,13 +4007,6 @@ CREATE INDEX index_uploads_on_deleted_at ON public.uploads USING btree (deleted_
 --
 
 CREATE UNIQUE INDEX index_user_auth_sources_on_user_connector_live ON public.user_authentication_sources USING btree (user_id, connector_id) WHERE (deleted_at IS NULL);
-
-
---
--- Name: index_user_authentication_sources_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_user_authentication_sources_on_deleted_at ON public.user_authentication_sources USING btree (deleted_at);
 
 
 --
@@ -5222,7 +4246,6 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260908120000'),
-('20260904120000'),
 ('20260827151000'),
 ('20260827150000'),
 ('20260820120000'),
@@ -5238,9 +4261,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260611120000'),
 ('20260520213800'),
 ('20260207120000'),
-('20260102144558'),
-('20260102144557'),
-('20251224185104'),
 ('20251215205826'),
 ('20251120143000'),
 ('20251106020333'),
@@ -5293,7 +4313,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20240401041826'),
 ('20240401041825'),
 ('20240401041824'),
-('20240326000000'),
 ('20240313162012'),
 ('20240313161801'),
 ('20240311135958'),
@@ -5345,11 +4364,11 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230429112954'),
 ('20230429112926'),
 ('20230429102609'),
+('20230426170051'),
 ('20230424123118'),
 ('20230420195221'),
 ('20230418170053'),
 ('20230412142430'),
-('20230330182609'),
 ('20230330161305'),
 ('20230328150855'),
 ('20230322204908'),

--- a/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
+++ b/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
@@ -84,12 +84,9 @@ module HudLsa
       raise ActiveRecord::RecordNotFound if export.blank?
 
       zip = export.hmis_zip
-      # Use the ActiveStorage version if we have it, otherwise the db attachment.
-      if zip.present?
-        send_data(zip.download, type: zip.content_type, filename: export.export_file_name)
-      else
-        send_data(export.content, filename: export.export_file_name, type: export.content_type, disposition: 'attachment')
-      end
+      raise ActiveRecord::RecordNotFound if zip.blank?
+
+      send_data(zip.download, type: zip.content_type, filename: export.export_file_name, disposition: 'attachment')
     end
 
     private def report

--- a/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
+++ b/drivers/hud_lsa/app/controllers/hud_lsa/lsas_controller.rb
@@ -11,7 +11,9 @@ module HudLsa
     include AjaxModalRails::Controller
     include ArelHelper
     before_action :filter
-    before_action :set_report, only: [:show, :destroy, :running, :download, :download_intermediate, :restore]
+    # Declared above set_report so the permission is checked before any record lookup.
+    before_action :require_can_download_lsa_source_data!, only: [:download_source_data]
+    before_action :set_report, only: [:show, :destroy, :running, :download, :download_intermediate, :download_source_data, :restore]
     before_action :set_reports, except: [:index, :running_all_questions]
 
     private def report_scope
@@ -73,6 +75,20 @@ module HudLsa
           filename = "Support for #{@report.class.generic_title}-#{@report.created_at.to_fs(:db)}.zip"
           send_data file.download, filename: filename, type: file.content_type, disposition: 'attachment'
         end
+      end
+    end
+
+    # The source HMIS data is an un-hashed HMIS CSV export produced by the LSA run.
+    def download_source_data
+      export = @report.export
+      raise ActiveRecord::RecordNotFound if export.blank?
+
+      zip = export.hmis_zip
+      # Use the ActiveStorage version if we have it, otherwise the db attachment.
+      if zip.present?
+        send_data(zip.download, type: zip.content_type, filename: export.export_file_name)
+      else
+        send_data(export.content, filename: export.export_file_name, type: export.content_type, disposition: 'attachment')
       end
     end
 

--- a/drivers/hud_lsa/app/views/hud_lsa/lsas/show.haml
+++ b/drivers/hud_lsa/app/views/hud_lsa/lsas/show.haml
@@ -21,9 +21,9 @@
         = link_to({ action: :download_intermediate, format: :zip}, {class: 'btn btn-secondary'}) do
           %span.icon-download2
           Supporting Files
-    - if @report.export_id
+    - if @report.export_id && current_user.can_download_lsa_source_data?
       .mt-2
-        = link_to(warehouse_reports_hmis_export_path(@report.export_id), {class: 'btn btn-secondary'}) do
+        = link_to({ action: :download_source_data }, {class: 'btn btn-secondary'}) do
           %span.icon-download2
           Source HMIS Data
 - if @report.purged?

--- a/drivers/hud_lsa/config/routes.rb
+++ b/drivers/hud_lsa/config/routes.rb
@@ -17,6 +17,7 @@ OpenPath::Application.routes.draw do
       get :download, on: :member
       post :restore, on: :member
       get :download_intermediate, on: :member
+      get :download_source_data, on: :member
     end
     resources :lsa_hics do
       get :running, on: :collection
@@ -27,6 +28,7 @@ OpenPath::Application.routes.draw do
       get :download, on: :member
       post :restore, on: :member
       get :download_intermediate, on: :member
+      get :download_source_data, on: :member
     end
   end
 end

--- a/drivers/hud_lsa/spec/requests/lsas_source_data_spec.rb
+++ b/drivers/hud_lsa/spec/requests/lsas_source_data_spec.rb
@@ -108,6 +108,19 @@ RSpec.describe 'LSA source data download', type: :request do
       end
     end
 
+    # can_download_lsa_source_data is additive -- HudReports::BaseController's
+    # require_can_view_hud_reports! still has to be satisfied to reach the action.
+    context 'holding can_download_lsa_source_data but no HUD report permission' do
+      let(:permissions) { { can_download_lsa_source_data: true } }
+
+      it 'redirects and sends no export content' do
+        get download_source_data_hud_reports_lsa_path(report)
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.body).not_to include('zip-data')
+      end
+    end
+
     context 'without can_download_lsa_source_data' do
       it 'redirects and sends no export content' do
         get download_source_data_hud_reports_lsa_path(report)

--- a/drivers/hud_lsa/spec/requests/lsas_source_data_spec.rb
+++ b/drivers/hud_lsa/spec/requests/lsas_source_data_spec.rb
@@ -1,0 +1,189 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'LSA source data download', type: :request do
+  include AccessControlSetup
+
+  let(:user) { create(:acl_user) }
+  let(:other_user) { create(:acl_user) }
+  let(:collection) { create(:collection) }
+  let(:export) { create(:grda_warehouse_hmis_export, :with_zip, content_type: 'application/zip') }
+
+  # Baseline: can reach the LSA report pages, but holds no source-data permission.
+  let(:permissions) { { can_view_own_hud_reports: true } }
+  let(:role) { create(:role, **permissions) }
+
+  # The controller already knows which fiscal year is current (its newest active
+  # entry in available_report_versions), so read it from there instead of naming a
+  # year here -- adding FY2028 to the controller moves these specs onto it.
+  def current_lsa_generator
+    controller = HudLsa::LsasController.new
+    controller.send(:possible_generator_classes).fetch(controller.default_report_version)
+  end
+
+  def create_lsa_report(owner: user, export_record: export, report_class: current_lsa_generator)
+    report_class.create!(
+      report_name: report_class.title,
+      user_id: owner.id,
+      export: export_record,
+      question_names: report_class.questions.keys,
+      options: {
+        user_id: owner.id,
+        coc_code: 'XX-500',
+        coc_codes: ['XX-500'],
+        start: Date.new(2024, 10, 1),
+        end: Date.new(2025, 9, 30),
+        project_ids: [],
+      },
+    )
+  end
+
+  before do
+    setup_access_control(user, role, collection)
+    sign_in(user)
+  end
+
+  describe 'GET download_source_data' do
+    let!(:report) { create_lsa_report }
+
+    context 'with can_download_lsa_source_data' do
+      let(:permissions) { { can_view_own_hud_reports: true, can_download_lsa_source_data: true } }
+
+      it 'sends the export content' do
+        get download_source_data_hud_reports_lsa_path(report)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('zip-data')
+      end
+
+      it '404s when the report has no export' do
+        no_export = create_lsa_report(export_record: nil)
+
+        get download_source_data_hud_reports_lsa_path(no_export)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'serves a retired fiscal year report' do
+        retired = create_lsa_report(report_class: HudLsa::Generators::Fy2024::Lsa)
+
+        get download_source_data_hud_reports_lsa_path(retired)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq('zip-data')
+      end
+
+      it "404s on another user's report" do
+        theirs = create_lsa_report(owner: other_user)
+
+        get download_source_data_hud_reports_lsa_path(theirs)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context 'as a report admin' do
+        let(:permissions) do
+          {
+            can_view_own_hud_reports: true,
+            can_view_all_hud_reports: true,
+            can_download_lsa_source_data: true,
+          }
+        end
+
+        it "serves another user's report" do
+          theirs = create_lsa_report(owner: other_user)
+
+          get download_source_data_hud_reports_lsa_path(theirs)
+
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq('zip-data')
+        end
+      end
+    end
+
+    context 'without can_download_lsa_source_data' do
+      it 'redirects and sends no export content' do
+        get download_source_data_hud_reports_lsa_path(report)
+
+        expect(response).to have_http_status(:redirect)
+        expect(response.body).not_to include('zip-data')
+      end
+
+      # can_export_hmis_data governs the shared HMIS Exports page, not this one.
+      context 'even holding can_export_hmis_data' do
+        let(:permissions) { { can_view_own_hud_reports: true, can_export_hmis_data: true } }
+
+        it 'redirects' do
+          get download_source_data_hud_reports_lsa_path(report)
+
+          expect(response).to have_http_status(:redirect)
+          expect(response.body).not_to include('zip-data')
+        end
+      end
+
+      # The permission check precedes set_report, so the response cannot be used to
+      # tell an existing report id from a missing one.
+      it "redirects rather than 404s on another user's report" do
+        theirs = create_lsa_report(owner: other_user)
+
+        get download_source_data_hud_reports_lsa_path(theirs)
+
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it 'redirects on the HIC route as well' do
+        hic = create_lsa_report
+        hic.update!(options: hic.options.merge('lsa_scope' => HudLsa::Fy2026::Report.available_lsa_scopes['HIC']))
+
+        get download_source_data_hud_reports_lsa_hic_path(hic)
+
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  describe 'the Source HMIS Data link on the LSA report page' do
+    let!(:report) { create_lsa_report }
+
+    context 'with can_download_lsa_source_data' do
+      let(:permissions) { { can_view_own_hud_reports: true, can_download_lsa_source_data: true } }
+
+      it 'points at the LSA download action' do
+        get hud_reports_lsa_path(report)
+
+        expect(response.body).to include("href=\"#{download_source_data_hud_reports_lsa_path(report)}\"")
+      end
+
+      # A revert of the repoint would put the shared exports controller back in play.
+      it 'no longer links to the shared HMIS exports page' do
+        get hud_reports_lsa_path(report)
+
+        expect(response.body).not_to include('warehouse_reports/hmis_exports/')
+      end
+
+      it 'is absent when the report has no export' do
+        no_export = create_lsa_report(export_record: nil)
+
+        get hud_reports_lsa_path(no_export)
+
+        expect(response.body).not_to include("href=\"#{download_source_data_hud_reports_lsa_path(no_export)}\"")
+      end
+    end
+
+    context 'without can_download_lsa_source_data' do
+      it 'is not offered' do
+        get hud_reports_lsa_path(report)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("href=\"#{download_source_data_hud_reports_lsa_path(report)}\"")
+      end
+    end
+  end
+end

--- a/spec/factories/grda_warehouse/hmis_exports.rb
+++ b/spec/factories/grda_warehouse/hmis_exports.rb
@@ -13,7 +13,11 @@ FactoryBot.define do
 
     trait :with_zip do
       after(:build) do |export|
-        export.content = 'zip-data'
+        export.hmis_zip.attach(
+          io: StringIO.new('zip-data'),
+          filename: 'export.zip',
+          content_type: 'application/zip',
+        )
       end
     end
   end

--- a/spec/models/role_lsa_source_data_permission_spec.rb
+++ b/spec/models/role_lsa_source_data_permission_spec.rb
@@ -1,0 +1,41 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Role, type: :model do
+  describe 'can_download_lsa_source_data' do
+    it 'is a registered permission' do
+      expect(Role.permissions).to include(:can_download_lsa_source_data)
+    end
+
+    it 'has a column on roles' do
+      expect(Role.column_names).to include('can_download_lsa_source_data')
+    end
+
+    it 'is described for the admin UI' do
+      metadata = Role.permissions_with_descriptions[:can_download_lsa_source_data]
+
+      expect(metadata[:description]).to be_present
+      expect(metadata[:category]).to eq('Reporting')
+      expect(metadata[:sub_category]).to eq('Exporting')
+      expect(metadata[:administrative]).to eq(false)
+    end
+
+    # Encodes the no-backfill decision: a role has to be granted this explicitly.
+    it 'defaults to false on a new role' do
+      expect(create(:role).can_download_lsa_source_data).to eq(false)
+    end
+
+    it 'is not implied by can_export_hmis_data' do
+      role = create(:role, can_export_hmis_data: true)
+
+      expect(role.can_download_lsa_source_data).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

## Summary

Downloading the source HMIS data attached to an LSA report run now requires its own permission, granted per role. Roles without it no longer see or reach that download; the same data remains available through the HMIS Export report, which is controlled separately.

Roles that could already export HMIS data receive the new permission automatically, so no one loses access at deploy. Any role created after that must be granted it explicitly.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [X] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

