### PR TITLE
[#9461] Add a single-client focused IdentifyDuplicates path

### DIFF
--- a/app/models/grda_warehouse/tasks/identify_duplicates.rb
+++ b/app/models/grda_warehouse/tasks/identify_duplicates.rb
@@ -17,10 +17,19 @@ module GrdaWarehouse::Tasks
     include NotifierConfig
     include Memery
     MAX_SOURCE_CLIENTS = 50
+    # Yield the advisory lock, and re-queue after PER_CLIENT_LOCK_TIMEOUT_SECONDS when procssing a single source client
+    PER_CLIENT_LOCK_TIMEOUT_SECONDS = 5
 
     def initialize(run_post_processing: true)
       setup_notifier('IdentifyDuplicates')
       @run_post_processing = run_post_processing
+    end
+
+    # Helper method to enqueue a run unless one is already enqueued
+    def self.enqueue_full_run!
+      return if Delayed::Job.queued?(['GrdaWarehouse::Tasks::IdentifyDuplicates', 'run!'])
+
+      new.delay(queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)).run!
     end
 
     def run!
@@ -30,6 +39,18 @@ module GrdaWarehouse::Tasks
       msg = 'Skipping identify duplicates, all ready running.'
       Rails.logger.warn msg
       @notifier.ping(msg) if @send_notifications
+    end
+
+    # For a given source client, run identify duplicates against existing destination clients
+    def process_source_client!(source_client_id)
+      acquired = GrdaWarehouseBase.with_advisory_lock('identify_duplicates', timeout_seconds: PER_CLIENT_LOCK_TIMEOUT_SECONDS) do
+        identify_duplicates_for_source(source_client_id)
+        true
+      end
+      return if acquired
+
+      Rails.logger.warn "IdentifyDuplicates: Waited #{PER_CLIENT_LOCK_TIMEOUT_SECONDS} seconds lock was not acquired, enqueueing a full run instead of processing client #{source_client_id}"
+      self.class.enqueue_full_run!
     end
 
     # Deduplicates client records by:
@@ -45,7 +66,7 @@ module GrdaWarehouse::Tasks
       restore_previously_deleted_destinations
 
       Rails.logger.info 'Loading unprocessed clients'
-      started_at = DateTime.now
+      started_at = DateTime.current
 
       @dnd_warehouse_data_source = GrdaWarehouse::DataSource.destination.first
       return unless @dnd_warehouse_data_source
@@ -68,94 +89,17 @@ module GrdaWarehouse::Tasks
       # ===========================================================================
 
       # Find all potential matches
-      more_than_one_match = find_merge_candidates_for_unprocessed.sort
-      more_than_one_match = more_than_one_match.map(&:reverse).to_h
-
-      # At this point more_than_one_match contains pairs of source client id and destination client id where the
-      # source client should be merged into the destination client.
-      # If the source client does not exist in any of the pairs, a new destination client should be created for it.
-      destination_clients_by_id = GrdaWarehouse::Hud::Client.destination.where(id: more_than_one_match.values).index_by(&:id)
+      matched_destinations = matched_destinations_by_source_id
 
       unprocessed.find_in_batches do |batch|
-        matched_ids = []
-        destination_client_updates = []
-        new_destination_clients = []
-        new_warehouse_clients = {}
-        source_client_ids_with_new_destination_clients = []
-
-        batch.each do |client|
-          destination_client = nil
-          if more_than_one_match.key?(client.id)
-            matched += 1
-            # Pick the first matching pair that includes this unmatched client
-            # Scenarios:
-            # 1. Simple: 1 destination, 1 unmatched source client with matching PII (will find the one pair)
-            # 2. 2 destinations share one of three PII fields, 1 source client that matches one of the two destinations (will find the matching destination)
-            # 3. 2 with identical PII, previously split to indicate they are not the same person, 1 source client with matching PII (will create a single pair with one of the destination clients).  This is ok, because we know the destination clients are not the same, but we don't know which the source should be connected to, so just pick one (we're sorting above to always pick the same one)
-            destination_id = more_than_one_match[client.id]
-            matched_ids << destination_id
-            new_warehouse_clients[client.id] = GrdaWarehouse::WarehouseClient.new(
-              id_in_source: client.personal_id,
-              source_id: client.id,
-              destination_id: destination_id,
-              data_source_id: client.data_source_id,
-            )
-
-            destination_client = destination_clients_by_id[destination_id]
-            # Set SSN & DOB if we have it in the incoming client, but not in the destination
-            destination_client.dob ||= client.dob if client&.dob.present?
-            destination_client.ssn ||= client.ssn if client&.ssn.present?
-            destination_client.first_name ||= client.first_name if client&.first_name.present?
-            destination_client.last_name ||= client.last_name if client&.last_name.present?
-
-            # set non-nullable fields, these aren't used because of the column limitation on import
-            # but Postgres complains if they aren't there
-            destination_client.personal_id = client.personal_id
-            destination_client.data_source_id = @dnd_warehouse_data_source.id
-            destination_client_updates << destination_client if destination_client.changed?
-          else
-            new_created += 1
-            destination_client = client.dup
-            destination_client.data_source_id = @dnd_warehouse_data_source.id
-            destination_client.apply_housing_release_status
-            new_destination_clients << destination_client
-            source_client_ids_with_new_destination_clients << client.id
-
-            new_warehouse_clients[client.id] = GrdaWarehouse::WarehouseClient.new(
-              id_in_source: client.personal_id,
-              source_id: client.id,
-              destination_id: nil, # Destination client hasn't been saved, so has no id yet
-              data_source_id: client.data_source_id,
-            )
-          end
-        end
-        # Persist any updates to destination clients
-        GrdaWarehouse::Hud::Client.import(
-          destination_client_updates.uniq { |m| m[:id] }, # ensure no duplicate rows
-          on_duplicate_key_update: {
-            conflict_target: [:id],
-            columns: [:SSN, :DOB, :FirstName, :LastName],
-          },
-          validate: false,
-        )
-        # Create new destination clients
-        new_destination_ids = GrdaWarehouse::Hud::Client.import(new_destination_clients).ids
-
-        # Update warehouse clients with new destination IDs
-        source_client_ids_with_new_destination_clients.zip(new_destination_ids).each do |source_id, destination_id|
-          new_warehouse_clients[source_id][:destination_id] = destination_id
-        end
-        GrdaWarehouse::WarehouseClient.import(new_warehouse_clients.values)
-
-        post_process_clients(
-          client_ids: destination_client_updates.map(&:id) + matched_ids + new_destination_ids,
-        )
-        GrdaWarehouse::Hud::Client.where(id: matched_ids).find_each(&:invalidate_service_history)
+        result = process_unprocessed_batch(batch, matched_destinations)
+        matched += result[:matched]
+        new_created += result[:new_created]
       end
       # Cleanup any proposed matches that might have been affected
       GrdaWarehouse::ClientMatch.accept_exact_matches!
       # Record completed run
-      completed_at = DateTime.now
+      completed_at = DateTime.current
       GrdaWarehouse::IdentifyDuplicatesLog.create!(
         started_at: started_at,
         completed_at: completed_at,
@@ -230,6 +174,144 @@ module GrdaWarehouse::Tasks
       return unless @run_post_processing
 
       GrdaWarehouse::Tasks::ServiceHistory::Add.new(force_sequential_processing: true).run!
+    end
+
+    # Called when a single source client is being processed.
+    # Returns early if the client already has a destination client.
+    # Finds possible matches more efficiently for a single client than the full batch mode.
+    private def identify_duplicates_for_source(source_client_id)
+      client = GrdaWarehouse::Hud::Client.source.find_by(id: source_client_id)
+      return if client.nil? || client.DateDeleted.present?
+      return if GrdaWarehouse::WarehouseClient.where(source_id: client.id).exists?
+
+      @dnd_warehouse_data_source = GrdaWarehouse::DataSource.destination.first
+      return unless @dnd_warehouse_data_source
+
+      started_at = DateTime.current
+      # Every 2-of-3 match shares SSN or DOB, so only destinations with one of those in common
+      # can qualify. Restricting the existing queries to them avoids scanning every destination.
+      @restrict_to_source_ids = [client.id]
+      @candidate_destination_ids = candidate_destination_ids_for(client)
+      matched_destinations = @candidate_destination_ids.any? ? matched_destinations_by_source_id : {}
+
+      result = process_unprocessed_batch([client], matched_destinations)
+      return if result[:destination_ids].empty?
+
+      GrdaWarehouse::IdentifyDuplicatesLog.create!(
+        started_at: started_at,
+        completed_at: DateTime.current,
+        to_match: 1,
+        matched: result[:matched],
+        new_created: result[:new_created],
+      )
+      # Rebuild service history for the destination in the background; the full run's
+      # accept_exact_matches! does this for everyone, which is far more than one client needs.
+      GrdaWarehouse::Tasks::ServiceHistory::Add.
+        delay(queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)).
+        queue_clients(result[:destination_ids])
+    end
+
+    # Destination clients sharing the source's usable SSN or DOB. A superset of what can match:
+    # the match queries still apply their own filters.
+    private def candidate_destination_ids_for(client)
+      destinations = GrdaWarehouse::Hud::Client.destination.where(DateDeleted: nil)
+      ids = []
+      ids += destinations.where(SSN: client.ssn).pluck(:id) if ::HudHelper.util.valid_social?(client.ssn)
+      ids += destinations.where(DOB: client.dob).pluck(:id) if client.dob.present?
+      ids.uniq
+    end
+
+    # Pairs each unprocessed source with a candidate destination. When several
+    # destinations qualify, sorts by [destination, source] pairs and then builds a hash
+    # keeping the highest destination id, so the choice is deterministic.
+    private def matched_destinations_by_source_id
+      find_merge_candidates_for_unprocessed.sort.map(&:reverse).to_h
+    end
+
+    # Links or creates destinations for one batch of source clients. Sources that gained a
+    # warehouse_clients row since the batch was selected are skipped, and the final import
+    # ignores duplicates, so a concurrent per-client run does not raise.
+    # @return [Hash] matched and new_created counts plus the destination ids touched
+    private def process_unprocessed_batch(batch, matched_destinations_by_source_id)
+      already_linked = GrdaWarehouse::WarehouseClient.where(source_id: batch.map(&:id)).pluck(:source_id).to_set
+      batch = batch.reject { |client| already_linked.include?(client.id) }
+      return { matched: 0, new_created: 0, destination_ids: [] } if batch.empty?
+
+      destination_ids = batch.filter_map { |client| matched_destinations_by_source_id[client.id] }
+      destination_clients_by_id = GrdaWarehouse::Hud::Client.destination.where(id: destination_ids).index_by(&:id)
+
+      matched = 0
+      new_created = 0
+      matched_ids = []
+      destination_client_updates = []
+      new_destination_clients = []
+      new_warehouse_clients = {}
+      source_client_ids_with_new_destination_clients = []
+
+      batch.each do |client|
+        destination_client = nil
+        if matched_destinations_by_source_id.key?(client.id)
+          matched += 1
+          destination_id = matched_destinations_by_source_id[client.id]
+          matched_ids << destination_id
+          new_warehouse_clients[client.id] = GrdaWarehouse::WarehouseClient.new(
+            id_in_source: client.personal_id,
+            source_id: client.id,
+            destination_id: destination_id,
+            data_source_id: client.data_source_id,
+          )
+
+          destination_client = destination_clients_by_id[destination_id]
+          # Set SSN & DOB if we have it in the incoming client, but not in the destination
+          destination_client.dob ||= client.dob if client&.dob.present?
+          destination_client.ssn ||= client.ssn if client&.ssn.present?
+          destination_client.first_name ||= client.first_name if client&.first_name.present?
+          destination_client.last_name ||= client.last_name if client&.last_name.present?
+
+          # set non-nullable fields, these aren't used because of the column limitation on import
+          # but Postgres complains if they aren't there
+          destination_client.personal_id = client.personal_id
+          destination_client.data_source_id = @dnd_warehouse_data_source.id
+          destination_client_updates << destination_client if destination_client.changed?
+        else
+          new_created += 1
+          destination_client = client.dup
+          destination_client.data_source_id = @dnd_warehouse_data_source.id
+          destination_client.apply_housing_release_status
+          new_destination_clients << destination_client
+          source_client_ids_with_new_destination_clients << client.id
+
+          new_warehouse_clients[client.id] = GrdaWarehouse::WarehouseClient.new(
+            id_in_source: client.personal_id,
+            source_id: client.id,
+            destination_id: nil, # Destination client hasn't been saved, so has no id yet
+            data_source_id: client.data_source_id,
+          )
+        end
+      end
+      # Persist any updates to destination clients
+      GrdaWarehouse::Hud::Client.import(
+        destination_client_updates.uniq { |m| m[:id] }, # ensure no duplicate rows
+        on_duplicate_key_update: {
+          conflict_target: [:id],
+          columns: [:SSN, :DOB, :FirstName, :LastName],
+        },
+        validate: false,
+      )
+      # Create new destination clients
+      new_destination_ids = GrdaWarehouse::Hud::Client.import(new_destination_clients).ids
+
+      # Update warehouse clients with new destination IDs
+      source_client_ids_with_new_destination_clients.zip(new_destination_ids).each do |source_id, destination_id|
+        new_warehouse_clients[source_id][:destination_id] = destination_id
+      end
+      GrdaWarehouse::WarehouseClient.import(new_warehouse_clients.values, on_duplicate_key_ignore: true)
+
+      touched_destination_ids = destination_client_updates.map(&:id) + matched_ids + new_destination_ids
+      post_process_clients(client_ids: touched_destination_ids)
+      GrdaWarehouse::Hud::Client.where(id: matched_ids).find_each(&:invalidate_service_history)
+
+      { matched: matched, new_created: new_created, destination_ids: touched_destination_ids.uniq }
     end
 
     # Marks given clients as dirty for future re-processing for CE
@@ -309,6 +391,7 @@ module GrdaWarehouse::Tasks
         match_type: :unprocessed,
         destination_data_source_ids: GrdaWarehouse::DataSource.destination_data_source_ids,
         unprocessed_ids: unprocessed_ids,
+        destination_ids: @candidate_destination_ids,
       ).execute
     end
 
@@ -325,6 +408,7 @@ module GrdaWarehouse::Tasks
         match_type: :unprocessed,
         destination_data_source_ids: GrdaWarehouse::DataSource.destination_data_source_ids,
         unprocessed_ids: unprocessed_ids,
+        destination_ids: @candidate_destination_ids,
       ).execute
     end
 
@@ -341,6 +425,7 @@ module GrdaWarehouse::Tasks
         match_type: :unprocessed,
         destination_data_source_ids: GrdaWarehouse::DataSource.destination_data_source_ids,
         unprocessed_ids: unprocessed_ids,
+        destination_ids: @candidate_destination_ids,
       ).execute
     end
 
@@ -492,6 +577,7 @@ module GrdaWarehouse::Tasks
             from "Client" as clients
             #{limits}
             and clients.data_source_id in (#{GrdaWarehouse::DataSource.destination_data_source_ids.join(',')})
+            #{candidate_destination_restriction_sql}
           ),
           client_two as (
           SELECT clients.id as source_client_id,
@@ -535,6 +621,7 @@ module GrdaWarehouse::Tasks
           from "Client" as clients
           #{limits}
           and clients.data_source_id in (#{GrdaWarehouse::DataSource.destination_data_source_ids.join(',')})
+          #{candidate_destination_restriction_sql}
         ),
         client_two_name as (
         SELECT clients.id as source_client_id,
@@ -574,6 +661,7 @@ module GrdaWarehouse::Tasks
             "Client" as clients
             #{limits}
             and clients.data_source_id in (#{GrdaWarehouse::DataSource.destination_data_source_ids.join(',')})
+            #{candidate_destination_restriction_sql}
         ),
         client_two_dob as (
           SELECT clients.id as source_client_id,
@@ -789,7 +877,16 @@ module GrdaWarehouse::Tasks
     end
 
     private def unprocessed_ids
+      return @restrict_to_source_ids if @restrict_to_source_ids.present?
+
       GrdaWarehouse::Hud::Client.source.pluck(:id) - GrdaWarehouse::WarehouseClient.pluck(:source_id)
+    end
+
+    # SQL fragment limiting the destination side of the legacy unprocessed queries; empty means no restriction.
+    private def candidate_destination_restriction_sql
+      return '' if @candidate_destination_ids.blank?
+
+      "and clients.id in (#{@candidate_destination_ids.map(&:to_i).join(',')})"
     end
 
     # fetch a list of existing clients from the DND Warehouse DataSource (current destinations)

--- a/app/models/grda_warehouse/tasks/identify_duplicates_query_matcher.rb
+++ b/app/models/grda_warehouse/tasks/identify_duplicates_query_matcher.rb
@@ -45,10 +45,11 @@ module GrdaWarehouse
       # @param match_type [Symbol] :existing or :unprocessed
       # @param destination_data_source_ids [Array<Integer>] Required for :unprocessed match_type
       # @param unprocessed_ids [Array<Integer>] Required for :unprocessed match_type
+      # @param destination_ids [Array<Integer>] Optional for :unprocessed match_type; limits the destination side to these client ids
       # @return [IdentifyDuplicatesQueryMatcher] Query matcher instance (call .execute to run)
       # @example
       #   IdentifyDuplicatesQueryMatcher.for_ssn_matches(match_type: :existing).execute
-      def self.for_ssn_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil)
+      def self.for_ssn_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil, destination_ids: nil)
         ensure_match_type!(match_type)
 
         new(
@@ -59,6 +60,7 @@ module GrdaWarehouse
           include_value_in_results: true,
           destination_data_source_ids: destination_data_source_ids,
           unprocessed_ids: unprocessed_ids,
+          destination_ids: destination_ids,
         )
       end
 
@@ -66,8 +68,9 @@ module GrdaWarehouse
       # @param match_type [Symbol] :existing or :unprocessed
       # @param destination_data_source_ids [Array<Integer>] Required for :unprocessed match_type
       # @param unprocessed_ids [Array<Integer>] Required for :unprocessed match_type
+      # @param destination_ids [Array<Integer>] Optional for :unprocessed match_type; limits the destination side to these client ids
       # @return [IdentifyDuplicatesQueryMatcher] Query matcher instance (call .execute to run)
-      def self.for_name_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil)
+      def self.for_name_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil, destination_ids: nil)
         ensure_match_type!(match_type)
 
         new(
@@ -78,6 +81,7 @@ module GrdaWarehouse
           include_value_in_results: false,
           destination_data_source_ids: destination_data_source_ids,
           unprocessed_ids: unprocessed_ids,
+          destination_ids: destination_ids,
         )
       end
 
@@ -85,8 +89,9 @@ module GrdaWarehouse
       # @param match_type [Symbol] :existing or :unprocessed
       # @param destination_data_source_ids [Array<Integer>] Required for :unprocessed match_type
       # @param unprocessed_ids [Array<Integer>] Required for :unprocessed match_type
+      # @param destination_ids [Array<Integer>] Optional for :unprocessed match_type; limits the destination side to these client ids
       # @return [IdentifyDuplicatesQueryMatcher] Query matcher instance (call .execute to run)
-      def self.for_dob_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil)
+      def self.for_dob_matches(match_type:, destination_data_source_ids: nil, unprocessed_ids: nil, destination_ids: nil)
         ensure_match_type!(match_type)
 
         new(
@@ -97,6 +102,7 @@ module GrdaWarehouse
           include_value_in_results: false,
           destination_data_source_ids: destination_data_source_ids,
           unprocessed_ids: unprocessed_ids,
+          destination_ids: destination_ids,
         )
       end
 
@@ -107,7 +113,7 @@ module GrdaWarehouse
       end
       private_class_method :ensure_match_type!
 
-      def initialize(match_type:, field_expression:, field_alias:, field_filters:, include_value_in_results:, destination_data_source_ids: nil, unprocessed_ids: nil)
+      def initialize(match_type:, field_expression:, field_alias:, field_filters:, include_value_in_results:, destination_data_source_ids: nil, unprocessed_ids: nil, destination_ids: nil)
         @match_type = match_type
         @field_expression = field_expression
         @field_alias = field_alias
@@ -115,6 +121,7 @@ module GrdaWarehouse
         @include_value_in_results = include_value_in_results
         @destination_data_source_ids = sanitize_ids(destination_data_source_ids)
         @unprocessed_ids = sanitize_ids(unprocessed_ids)
+        @destination_ids = sanitize_ids(destination_ids)
       end
 
       def to_sql(warehouse_id: nil)
@@ -150,7 +157,7 @@ module GrdaWarehouse
       private
 
       attr_reader :match_type, :field_expression, :field_alias, :field_filters, :include_value_in_results,
-                  :destination_data_source_ids, :unprocessed_ids, :warehouse_id
+                  :destination_data_source_ids, :unprocessed_ids, :destination_ids, :warehouse_id
 
       # Space-efficient approach: Groups all matching clients by field value into arrays,
       # then generates unique pairs using array indices. This avoids materializing
@@ -200,6 +207,7 @@ module GrdaWarehouse
               array_agg(DISTINCT clients.id ORDER BY clients.id) AS destination_ids
             #{unprocessed_from_clause}
               AND clients.data_source_id IN (#{destination_ids_sql})
+              #{destination_restriction_sql}
             GROUP BY #{field_alias}
           ),
           source_matches AS (
@@ -217,6 +225,13 @@ module GrdaWarehouse
           CROSS JOIN LATERAL generate_subscripts(destination_ids, 1) AS idx
           WHERE destination_ids[idx] != source_client_id
         SQL
+      end
+
+      # Limits the destination side to specific clients; empty means no restriction.
+      def destination_restriction_sql
+        return '' if destination_ids.blank?
+
+        "AND clients.id IN (#{destination_ids.join(', ')})"
       end
 
       def unprocessed_from_clause

--- a/db/warehouse/migrate/20260908120000_add_index_to_client_dob.rb
+++ b/db/warehouse/migrate/20260908120000_add_index_to_client_dob.rb
@@ -1,0 +1,21 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+class AddIndexToClientDOB < ActiveRecord::Migration[8.1]
+  def change
+    # Omit `algorithm: :concurrently`, so the migration runs in one transaction.
+    # This avoids needing disable_ddl_transaction! which we've had issues with in the past.
+    safety_assured do
+      add_index(
+        :Client,
+        :DOB,
+        name: :idx_client_dob,
+      )
+    end
+  end
+end

--- a/db/warehouse_structure.sql
+++ b/db/warehouse_structure.sql
@@ -213597,6 +213597,13 @@ CREATE INDEX idx_client_custom_names_last_idx ON public."CustomClientName" USING
 
 
 --
+-- Name: idx_client_dob; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_client_dob ON public."Client" USING btree ("DOB");
+
+
+--
 -- Name: idx_client_name_full_gin; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -359988,6 +359995,7 @@ ALTER TABLE ONLY public.import_logs
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260908120000'),
 ('20260819120200'),
 ('20260819120000'),
 ('20260818130528'),

--- a/docs/features/warehouse/identify-duplicates.md
+++ b/docs/features/warehouse/identify-duplicates.md
@@ -59,9 +59,9 @@ Each matching criterion has two implementations with different return types:
 
 Similar method pairs exist for name and DOB matching. The different return types reflect different architectural needs: linking new clients vs merging existing ones.
 
-## Two Main Operations
+## Main Operations
 
-The system provides two distinct operations that handle different deduplication scenarios:
+The system provides three operations that handle different deduplication scenarios:
 
 ### Operation 1: `identify_duplicates` - Process New/Unprocessed Clients
 
@@ -99,7 +99,23 @@ The system provides two distinct operations that handle different deduplication 
 5. Executes the merge by transferring all associated data and records from one client to another. After the core merge operation, a separate background job handles cleanup tasks, such as removing the now-redundant client record and updating related data to ensure consistency.
 6. Invalidates the existing service history for all clients involved in a merge. A background process is then initiated to rebuild a new, consolidated service history, ensuring all historical service events are accurately linked to the final destination client.
 
-### Why Two Separate Operations?
+### Operation 3: `process_source_client!` - Link One New Client
+
+**Purpose**: Links a single newly created source client to an existing destination or creates one for it.
+
+**When `process_source_client!` runs**:
+- After an HMIS client is created (enqueued from `after_commit` on the `short_running` queue, one job per client)
+
+**What `process_source_client!` does**:
+1. Returns immediately if the source is already linked, soft-deleted, or not a source client.
+2. Takes the same `identify_duplicates` advisory lock as the full run, waiting up to 5 seconds. If a full run holds the lock, it enqueues a full run instead so the client is still processed.
+3. Runs the same **Matching Criteria** queries as the full run, restricted to this source and to destination clients that share its SSN or DOB.
+4. Processes the newly matched client as with the batch process if a match is found, otherwise create a new destination from the source.
+5. Marks the destination dirty for Coordinated Entry, writes an `identify_duplicates_log` row with `to_match: 1`, and queues a background service history rebuild for the destination.
+
+It does not restore deleted destinations or accept pending `ClientMatch` candidates; the full run still handles those.
+
+### Why Separate Operations?
 
 **Logical Separation**:
 - **New client processing**: Handles incremental addition of clients over time, and additional bulk imports of client data.
@@ -136,6 +152,7 @@ The system requires **2 of 3** exact matches across these normalized fields:
 - Advisory locks prevent concurrent execution
 - Respects manual administrative decisions about client splits
 - Maintains audit trails of operations
+- The full run skips sources linked by a per-client run after its unprocessed list was computed, and its `warehouse_clients` insert ignores duplicates.
 
 ## Performance Optimizations
 

--- a/drivers/hmis/app/models/hmis/hud/client.rb
+++ b/drivers/hmis/app/models/hmis/hud/client.rb
@@ -91,7 +91,7 @@ class Hmis::Hud::Client < Hmis::Hud::Base
   validates_with Hmis::Hud::Validators::ClientValidator, on: [:client_form, :new_client_enrollment_form]
 
   # Order is: before_save => save => after_create|after_update > after_save
-  after_create :warehouse_identify_duplicate_clients
+  after_commit :warehouse_identify_duplicates_for_new_client, on: :create # using after_commit `on: :create` because Delayed::Job enqueues to a different database.  `after_create` calls are run before the transaction is committed, and could lead to a missing client record.
   after_update :warehouse_match_existing_clients
   before_save :set_source_hash
 
@@ -401,15 +401,16 @@ class Hmis::Hud::Client < Hmis::Hud::Base
     GrdaWarehouse::Tasks::IdentifyDuplicates.new.delay(queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)).match_existing!
   end
 
+  # Bulk callers (fake enrollment generation, MCI imports, undo-merge) enqueue a full run of identify duplicates.
   def self.warehouse_identify_duplicate_clients
-    return if Delayed::Job.where(failed_at: nil, locked_at: nil).jobs_for_class('GrdaWarehouse::Tasks::IdentifyDuplicates').jobs_for_class('run!').exists?
-
-    GrdaWarehouse::Tasks::IdentifyDuplicates.new.delay(queue: ENV.fetch('DJ_LONG_QUEUE_NAME', :long_running)).run!
+    GrdaWarehouse::Tasks::IdentifyDuplicates.enqueue_full_run!
   end
 
-  # Run when we add a new client to the system
-  private def warehouse_identify_duplicate_clients
-    self.class.warehouse_identify_duplicate_clients
+  # After creation of a single client run a more efficient per-client identify duplicates.
+  private def warehouse_identify_duplicates_for_new_client
+    GrdaWarehouse::Tasks::IdentifyDuplicates.new.
+      delay(queue: ENV.fetch('DJ_SHORT_QUEUE_NAME', :short_running)).
+      process_source_client!(id)
   end
 
   private def warehouse_columns_changed?

--- a/drivers/hmis/spec/support/shared_examples/submit_form.rb
+++ b/drivers/hmis/spec/support/shared_examples/submit_form.rb
@@ -30,16 +30,21 @@ RSpec.shared_examples 'submit form marks enrollment for re-processing' do
 end
 
 # Required lets: input.
-# Include for roles that trigger IdentifyDuplicates job: CLIENT, NEW_CLIENT_ENROLLMENT.
+# Include for roles that create a client: CLIENT, NEW_CLIENT_ENROLLMENT.
 RSpec.shared_examples 'submit form triggers IdentifyDuplicates job' do
-  it 'triggers IdentifyDuplicates job' do
+  it 'enqueues a per-client IdentifyDuplicates job on the short queue and no full run' do
     Delayed::Job.jobs_for_class(['GrdaWarehouse::Tasks::IdentifyDuplicates']).delete_all
 
-    expect do
-      submit_form(input)
-    end.to change(Delayed::Job, :count)
+    expect { submit_form(input) }.to change(Delayed::Job, :count)
 
-    expect(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::IdentifyDuplicates').count).to be_positive
+    jobs = Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::IdentifyDuplicates')
+    per_client_jobs = jobs.jobs_for_class('process_source_client!')
+    expect(per_client_jobs.count).to eq(1)
+    expect(jobs.jobs_for_class('run!')).to be_empty
+
+    job = per_client_jobs.first
+    expect(job.queue).to eq(ENV.fetch('DJ_SHORT_QUEUE_NAME', 'short_running'))
+    expect(job.handler).to include("- #{Hmis::Hud::Client.order(:id).last.id}\n")
   end
 end
 

--- a/spec/models/grda_warehouse/tasks/identify_duplicates_query_matcher_spec.rb
+++ b/spec/models/grda_warehouse/tasks/identify_duplicates_query_matcher_spec.rb
@@ -94,6 +94,35 @@ RSpec.describe GrdaWarehouse::Tasks::IdentifyDuplicatesQueryMatcher, type: :mode
         )
       end
     end
+
+    describe 'for unprocessed matches restricted to destination ids' do
+      let(:source_data_source) { create :source_data_source }
+      let(:destination_data_source) { create :grda_warehouse_data_source }
+      let!(:unprocessed) { create :grda_warehouse_hud_client, data_source: source_data_source, SSN: '212345678' }
+      let!(:destination_one) { create :grda_warehouse_hud_client, data_source: destination_data_source, SSN: '212345678' }
+      let!(:destination_two) { create :grda_warehouse_hud_client, data_source: destination_data_source, SSN: '212345678' }
+
+      it 'returns only pairs whose destination is in destination_ids' do
+        results = described_class.for_ssn_matches(
+          match_type: :unprocessed,
+          destination_data_source_ids: [destination_data_source.id],
+          unprocessed_ids: [unprocessed.id],
+          destination_ids: [destination_two.id],
+        ).execute(warehouse_id: destination_data_source.id)
+
+        expect(results).to eq([[destination_two.id, unprocessed.id]])
+      end
+
+      it 'returns every destination when destination_ids is nil' do
+        results = described_class.for_ssn_matches(
+          match_type: :unprocessed,
+          destination_data_source_ids: [destination_data_source.id],
+          unprocessed_ids: [unprocessed.id],
+        ).execute(warehouse_id: destination_data_source.id)
+
+        expect(results).to contain_exactly([destination_one.id, unprocessed.id], [destination_two.id, unprocessed.id])
+      end
+    end
   end
 
   describe '#execute' do

--- a/spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb
+++ b/spec/models/grda_warehouse/tasks/identify_duplicates_spec.rb
@@ -131,6 +131,219 @@ RSpec.describe GrdaWarehouse::Tasks::IdentifyDuplicates, type: :model do
       end
     end
 
+    describe 'identify_duplicates with a concurrently linked source' do
+      let(:processor) { GrdaWarehouse::Tasks::IdentifyDuplicates.new(run_post_processing: false) }
+
+      it 'skips a source that was linked after the unprocessed list was computed' do
+        # The list still names the source, but a per-client run has linked it in the meantime.
+        allow(processor).to receive(:unprocessed_ids).and_return([client_in_source.id])
+        create :warehouse_client, source: client_in_source, destination: client_in_destination, data_source: source_data_source
+
+        expect { processor.identify_duplicates }.
+          to not_change(destination_scope, :count).
+          and not_change(GrdaWarehouse::WarehouseClient, :count)
+      end
+    end
+
+    describe '#process_source_client!' do
+      let(:processor) { GrdaWarehouse::Tasks::IdentifyDuplicates.new(run_post_processing: false) }
+      let(:warehouse_client) { GrdaWarehouse::WarehouseClient.find_by(source_id: client_in_source.id) }
+      let(:last_log) { GrdaWarehouse::IdentifyDuplicatesLog.order(:id).last }
+
+      def set_pii(client, first_name:, last_name:, ssn:, dob:)
+        client.update_columns(FirstName: first_name, LastName: last_name, SSN: ssn, DOB: dob)
+      end
+
+      before { set_pii(client_in_source, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1985-03-04') }
+
+      shared_examples 'creates a new destination' do
+        it 'creates a destination in the warehouse data source and links the source to it' do
+          expect { processor.process_source_client!(client_in_source.id) }.
+            to change(destination_scope, :count).by(1).
+            and change(GrdaWarehouse::WarehouseClient, :count).by(1)
+
+          expect(warehouse_client.destination_id).not_to eq(client_in_destination.id)
+          expect(client_in_source.reload.destination_client.data_source_id).to eq(destination_data_source.id)
+          expect(warehouse_client.id_in_source).to eq(client_in_source.PersonalID)
+          expect(last_log).to have_attributes(to_match: 1, matched: 0, new_created: 1)
+        end
+      end
+
+      shared_examples 'links to the existing destination' do
+        it 'links the source without creating a destination' do
+          expect { processor.process_source_client!(client_in_source.id) }.
+            to change(GrdaWarehouse::WarehouseClient, :count).by(1).
+            and not_change(destination_scope, :count)
+
+          expect(warehouse_client.destination_id).to eq(client_in_destination.id)
+          expect(last_log).to have_attributes(to_match: 1, matched: 1, new_created: 0)
+        end
+      end
+
+      context 'when no destination shares two of SSN, name, and DOB' do
+        before { set_pii(client_in_destination, first_name: 'Grace', last_name: 'Hopper', ssn: '312345678', dob: '1985-03-04') }
+        include_examples 'creates a new destination'
+      end
+
+      context 'when a destination matches by SSN and DOB' do
+        before { set_pii(client_in_destination, first_name: 'Other', last_name: 'Person', ssn: '212345678', dob: '1985-03-04') }
+        include_examples 'links to the existing destination'
+      end
+
+      context 'when a destination matches by SSN and name' do
+        before { set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1970-01-01') }
+        include_examples 'links to the existing destination'
+      end
+
+      context 'when a destination matches by DOB and a name that differs only in case, punctuation, and accents' do
+        before { set_pii(client_in_destination, first_name: ' adá ', last_name: 'love-lace', ssn: nil, dob: '1985-03-04') }
+        include_examples 'links to the existing destination'
+      end
+
+      context 'when a placeholder SSN is the only second match' do
+        before do
+          set_pii(client_in_source, first_name: 'Zed', last_name: 'Zeta', ssn: '123456789', dob: '1985-03-04')
+          set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '123456789', dob: '1985-03-04')
+        end
+        include_examples 'creates a new destination'
+      end
+
+      context 'when a DOB from 1920 is the only second match' do
+        before do
+          set_pii(client_in_source, first_name: 'Zed', last_name: 'Zeta', ssn: '212345678', dob: '1920-06-01')
+          set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1920-06-01')
+        end
+        include_examples 'creates a new destination'
+      end
+
+      context 'when the only matching destination is soft-deleted' do
+        before do
+          set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1985-03-04')
+          client_in_destination.update_columns(DateDeleted: 1.day.ago)
+        end
+
+        it 'creates a new destination' do
+          expect { processor.process_source_client!(client_in_source.id) }.to change(GrdaWarehouse::WarehouseClient, :count).by(1)
+          expect(warehouse_client.destination_id).not_to eq(client_in_destination.id)
+        end
+      end
+
+      context 'when another source client has identical PII' do
+        before do
+          set_pii(client_in_destination, first_name: 'Other', last_name: 'Person', ssn: '312345678', dob: '1970-01-01')
+          create :grda_warehouse_hud_client, data_source: source_data_source, FirstName: 'Ada', LastName: 'Lovelace', SSN: '212345678', DOB: '1985-03-04'
+        end
+        include_examples 'creates a new destination'
+      end
+
+      context 'when several destinations match' do
+        let!(:second_destination) do
+          create :grda_warehouse_hud_client, data_source: destination_data_source, FirstName: 'Ada', LastName: 'Lovelace', SSN: '212345678', DOB: '1985-03-04'
+        end
+        before { set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1985-03-04') }
+
+        it 'links to the highest destination id, as the full run does' do
+          processor.process_source_client!(client_in_source.id)
+
+          expect(warehouse_client.destination_id).to eq([client_in_destination.id, second_destination.id].max)
+        end
+      end
+
+      context 'when linking to an existing destination' do
+        # Name + DOB match (2 of 3 criteria); SSN is left blank so the fill-in below is meaningful.
+        before { set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: nil, dob: '1985-03-04') }
+
+        it 'fills missing PII on the destination without overwriting existing values' do
+          processor.process_source_client!(client_in_source.id)
+
+          expect(client_in_destination.reload).to have_attributes(SSN: '212345678', FirstName: 'Ada', LastName: 'Lovelace')
+        end
+
+        it 'invalidates the destination service history' do
+          create :grda_warehouse_warehouse_clients_processed, client: client_in_destination
+
+          processor.process_source_client!(client_in_source.id)
+
+          expect(client_in_destination.reload.processed_service_history).to be_nil
+        end
+
+        it 'marks the destination dirty for CE' do
+          allow_any_instance_of(Hmis::Ce::Configuration).to receive(:enabled?).and_return(true)
+
+          processor.process_source_client!(client_in_source.id)
+
+          expect(Hmis::Ce::ChangeMarker.where(trackable_type: 'GrdaWarehouse::Hud::Client', trackable_id: client_in_destination.id)).to exist
+        end
+
+        it 'queues a background service history rebuild for the destination' do
+          Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Add').delete_all
+
+          processor.process_source_client!(client_in_source.id)
+
+          job = Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::ServiceHistory::Add').jobs_for_class('queue_clients').first
+          expect(job).to be_present
+          expect(job.handler).to include("- #{client_in_destination.id}\n")
+          expect(job.queue).to eq(ENV.fetch('DJ_LONG_QUEUE_NAME', 'long_running'))
+        end
+      end
+
+      context 'when auto deduplication is disabled' do
+        before do
+          @config.update(enable_auto_deduplication: false)
+          @config.invalidate_cache
+          set_pii(client_in_destination, first_name: 'Ada', last_name: 'Lovelace', ssn: '212345678', dob: '1985-03-04')
+        end
+        include_examples 'creates a new destination'
+      end
+
+      context 'when there is nothing to do' do
+        it 'is a no-op for a source that is already linked' do
+          create :warehouse_client, source: client_in_source, destination: client_in_destination, data_source: source_data_source
+
+          expect { processor.process_source_client!(client_in_source.id) }.
+            to not_change(GrdaWarehouse::WarehouseClient, :count).
+            and not_change(destination_scope, :count).
+            and not_change(GrdaWarehouse::IdentifyDuplicatesLog, :count).
+            and not_change(Delayed::Job, :count)
+        end
+
+        it 'is a no-op for a soft-deleted source' do
+          client_in_source.update_columns(DateDeleted: 1.day.ago)
+
+          expect { processor.process_source_client!(client_in_source.id) }.to not_change(GrdaWarehouse::WarehouseClient, :count)
+        end
+
+        it 'is a no-op for a destination client id' do
+          expect { processor.process_source_client!(client_in_destination.id) }.to not_change(GrdaWarehouse::WarehouseClient, :count)
+        end
+
+        it 'is a no-op for an unknown id' do
+          expect { processor.process_source_client!(-1) }.to not_change(GrdaWarehouse::WarehouseClient, :count)
+        end
+      end
+
+      context 'when the advisory lock is held by a full run' do
+        before do
+          allow(GrdaWarehouseBase).to receive(:with_advisory_lock).
+            with('identify_duplicates', hash_including(timeout_seconds: GrdaWarehouse::Tasks::IdentifyDuplicates::PER_CLIENT_LOCK_TIMEOUT_SECONDS)).
+            and_return(false)
+          Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::IdentifyDuplicates').delete_all
+        end
+
+        it 'enqueues a full run instead of linking' do
+          expect { processor.process_source_client!(client_in_source.id) }.to not_change(GrdaWarehouse::WarehouseClient, :count)
+
+          expect(Delayed::Job.jobs_for_class('GrdaWarehouse::Tasks::IdentifyDuplicates').jobs_for_class('run!').count).to eq(1)
+        end
+
+        it 'does not enqueue a second full run when one is waiting' do
+          processor.process_source_client!(client_in_source.id)
+
+          expect { processor.process_source_client!(client_in_source.id) }.to not_change(Delayed::Job, :count)
+        end
+      end
+    end
+
     describe 'When the client has non-ascii characters in their name' do
       before do
         client_in_destination.update(first_name: 'José')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Adjusts the HMIS client creation process to be small and fast enough to run in the short DJ queue.

Adds a method for matching a single source client, with effient limiting of queries and processing to speed things up.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature,

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [x] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

