### PR TITLE
[#9600] Scope CE APR Q9d result rows to residential referrals

### DIFF
--- a/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/question_nine.rb
+++ b/drivers/hud_apr/app/models/hud_apr/generators/ce_apr/fy2026/question_nine.rb
@@ -116,6 +116,10 @@ module HudApr::Generators::CeApr::Fy2026
       end
     end
 
+    private def q9d_residential_referral_events
+      (10..15).to_a + [17, 18]
+    end
+
     private def q9d_table_rows
       {
         'Post-placement/follow-up case management' => a_t[:ce_event_event].eq(5),
@@ -134,13 +138,13 @@ module HudApr::Generators::CeApr::Fy2026
         'Referral to a Housing Stability Voucher' => a_t[:ce_event_event].eq(18),
         'Total' => a_t[:ce_event_event].in((5..18).to_a),
         'Of the total HH prioritized (Q9b row 1) what percentage received a referral' => Arel.sql('0=1'), # This will be calculated as a separate step
-        'Result: successful referral: client accepted' => a_t[:ce_event_referral_result].eq(1).and(a_t[:ce_event_event].in((5..18).to_a)),
-        'Result: Unsuccessful referral: client rejected' => a_t[:ce_event_referral_result].eq(2).and(a_t[:ce_event_event].in((5..18).to_a)),
-        'Result: Unsuccessful referral: provider rejected' => a_t[:ce_event_referral_result].eq(3).and(a_t[:ce_event_event].in((5..18).to_a)),
+        'Result: successful referral: client accepted' => a_t[:ce_event_referral_result].eq(1).and(a_t[:ce_event_event].in(q9d_residential_referral_events)),
+        'Result: Unsuccessful referral: client rejected' => a_t[:ce_event_referral_result].eq(2).and(a_t[:ce_event_event].in(q9d_residential_referral_events)),
+        'Result: Unsuccessful referral: provider rejected' => a_t[:ce_event_referral_result].eq(3).and(a_t[:ce_event_event].in(q9d_residential_referral_events)),
         # Based on 2022 Data Dictionary p. 43 instead of the CE APR spec, pending AAQ
         'No result recorded' => a_t[:ce_event_event].eq(2).and(a_t[:ce_event_problem_sol_div_rr_result].eq(nil)).
           or(a_t[:ce_event_event].eq(5).and(a_t[:ce_event_referral_case_manage_after].eq(nil))).
-          or(a_t[:ce_event_event].in((10..15).to_a + (17..18).to_a).and(a_t[:ce_event_referral_result].eq(nil))),
+          or(a_t[:ce_event_event].in(q9d_residential_referral_events).and(a_t[:ce_event_referral_result].eq(nil))),
         'Result: Enrolled in Aftercare project' => a_t[:ce_event_referral_case_manage_after].eq(1),
         'Percent of successful referrals to residential projects' => Arel.sql('0=1'), # This will be calculated as a separate step
       }.freeze


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`
- use a merge-commit or rebase strategy for PRs targeting `staging` and `production`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

Rows 18-21 filtered ReferralResult across all referral events (5-18), while row 23 divides row 18 by the residential and voucher rows only. The percentage could therefore exceed 100%, or return Inf when there were no residential referrals at all.

The result rows now use the same event set as that denominator (rows 7-12, 14 and 15). Two sources confirm it:
- 4.20 Dependent D collects ReferralResult only for events 10-15 and 18 (17 is retired).
- HUD's Data Lab CE_APR.R filters these rows with c(10:15, 17:18).

Row 21 already used this set, so its clause is only refactored.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [X] I performed a self-review of my code
- [X] I ran the OP review skill
- [X] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [ ] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

