### PR TITLE
Data Source Show Page Adjustment

### DIFF
--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -790,28 +790,28 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
     )
   end
 
-  # Below this size and dominance, a data source's organizations page can render
-  # everything at once; otherwise it's large or fragmented enough that the user
-  # should pick a CoC to filter by first.
+  # A data source's show page renders every project at once unless the list is
+  # large *and* picking a CoC would meaningfully shrink it. A CoC choice is only required when
+  # there are at least two CoCs, the project count reaches SMALL_ENOUGH_PROJECT_COUNT,
+  # the projects outside the largest CoC together reach SMALL_ENOUGH_FRAGMENT_COUNT, and the
+  # largest CoC holds less than DOMINANT_COC_SHARE of the total.
   SMALL_ENOUGH_PROJECT_COUNT = Rails.env.development? ? 100 : 1000
+  SMALL_ENOUGH_FRAGMENT_COUNT = Rails.env.development? ? 5 : 50
   DOMINANT_COC_SHARE = Rails.env.development? ? 0.90 : 0.75
 
   # project_scope must be a viewable-projects scope (e.g. GrdaWarehouse::Hud::Project.viewable_by(...)),
   # not yet narrowed to this data source or any particular CoC code — the point here is deciding
   # whether a CoC choice is needed at all, based on what this user could otherwise see all at once.
   def require_coc_choice?(project_scope)
-    project_scope = project_scope.where(data_source_id: id)
-    return true if project_scope.count >= SMALL_ENOUGH_PROJECT_COUNT
+    counts = coc_code_bucket_scope(project_scope.where(data_source_id: id)).count.values
+    return false if counts.size < 2
 
-    dominant_coc_share(project_scope) < DOMINANT_COC_SHARE
-  end
-
-  private def dominant_coc_share(project_scope)
-    counts = coc_code_bucket_scope(project_scope).count.values
     total = counts.sum
-    return 1.0 if total.zero?
+    dominant = counts.max
+    return false if total < SMALL_ENOUGH_PROJECT_COUNT
+    return false if total - dominant < SMALL_ENOUGH_FRAGMENT_COUNT
 
-    counts.max.to_f / total
+    dominant.to_f / total < DOMINANT_COC_SHARE
   end
 
   # One summary row per distinct CoC code (plus an "unknown" bucket for projects with

--- a/app/models/grda_warehouse/data_source.rb
+++ b/app/models/grda_warehouse/data_source.rb
@@ -791,25 +791,29 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
   end
 
   # A data source's show page renders every project at once unless the list is
-  # large *and* picking a CoC would meaningfully shrink it. A CoC choice is only required when
-  # there are at least two CoCs, the project count reaches SMALL_ENOUGH_PROJECT_COUNT,
-  # the projects outside the largest CoC together reach SMALL_ENOUGH_FRAGMENT_COUNT, and the
-  # largest CoC holds less than DOMINANT_COC_SHARE of the total.
-  SMALL_ENOUGH_PROJECT_COUNT = Rails.env.development? ? 100 : 1000
-  SMALL_ENOUGH_FRAGMENT_COUNT = Rails.env.development? ? 5 : 50
+  # large and picking a CoC would meaningfully shrink it. A CoC choice is only required when
+  # there are at least two CoCs, the project count reaches MIN_PROJECT_COUNT_FOR_COC_CHOICE,
+  # the projects outside the largest CoC together reach MIN_FRAGMENT_COUNT_FOR_COC_CHOICE, and
+  # the largest CoC holds less than DOMINANT_COC_SHARE of the total.
+  #
+  # Counts are distinct projects per CoC, the same figures coc_summaries puts on the picker
+  # cards: a project with several ProjectCoc rows in one CoC counts once there, and a project
+  # in several CoCs counts once in each.
+  MIN_PROJECT_COUNT_FOR_COC_CHOICE = Rails.env.development? ? 100 : 1000
+  MIN_FRAGMENT_COUNT_FOR_COC_CHOICE = Rails.env.development? ? 5 : 50
   DOMINANT_COC_SHARE = Rails.env.development? ? 0.90 : 0.75
 
   # project_scope must be a viewable-projects scope (e.g. GrdaWarehouse::Hud::Project.viewable_by(...)),
   # not yet narrowed to this data source or any particular CoC code — the point here is deciding
   # whether a CoC choice is needed at all, based on what this user could otherwise see all at once.
   def require_coc_choice?(project_scope)
-    counts = coc_code_bucket_scope(project_scope.where(data_source_id: id)).count.values
+    counts = coc_code_bucket_scope(project_scope.where(data_source_id: id)).count(DISTINCT_PROJECT_ID).values
     return false if counts.size < 2
 
     total = counts.sum
     dominant = counts.max
-    return false if total < SMALL_ENOUGH_PROJECT_COUNT
-    return false if total - dominant < SMALL_ENOUGH_FRAGMENT_COUNT
+    return false if total < MIN_PROJECT_COUNT_FOR_COC_CHOICE
+    return false if total - dominant < MIN_FRAGMENT_COUNT_FOR_COC_CHOICE
 
     dominant.to_f / total < DOMINANT_COC_SHARE
   end
@@ -822,7 +826,7 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
   # scope not yet narrowed to this data source or any particular CoC code.
   def coc_summaries(project_scope)
     scope = coc_code_bucket_scope(project_scope)
-    project_counts = scope.count('DISTINCT "Project"."id"')
+    project_counts = scope.count(DISTINCT_PROJECT_ID)
     org_counts = scope.count('DISTINCT "Project"."OrganizationID"')
 
     project_counts.map do |code, project_count|
@@ -850,6 +854,9 @@ class GrdaWarehouse::DataSource < GrdaWarehouseBase
       GrdaWarehouse::DataSource.viewable_by(user, permission: :can_view_clients).exists?(id: id)
     end
   end
+
+  DISTINCT_PROJECT_ID = 'DISTINCT "Project"."id"'
+  private_constant :DISTINCT_PROJECT_ID
 
   # Group nil, empty, and whitespace-only CoC codes into a single bucket, matching
   # ProjectCoc.unknown_coc.

--- a/spec/models/grda_warehouse/data_source_spec.rb
+++ b/spec/models/grda_warehouse/data_source_spec.rb
@@ -716,12 +716,12 @@ RSpec.describe model, type: :model do
     let!(:org) { create(:hud_organization, data_source_id: ds.id) }
     let(:all_projects) { GrdaWarehouse::Hud::Project.all }
 
-    # Small thresholds keep fixtures cheap while still letting each rule be crossed independently:
-    # with 4 total and 3 fragments, a source can be at the size gate with fragments under the
-    # fragment gate (2/1/1) while still being under the dominance threshold.
+    # With a size gate of 6 and a fragment gate of 3, each gate can be the only rule that
+    # blocks a choice: 2/2/1 fails size alone, 4/1/1 fails fragments alone, 9/3 fails
+    # dominance alone.
     before do
-      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_PROJECT_COUNT', 4)
-      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_FRAGMENT_COUNT', 3)
+      stub_const('GrdaWarehouse::DataSource::MIN_PROJECT_COUNT_FOR_COC_CHOICE', 6)
+      stub_const('GrdaWarehouse::DataSource::MIN_FRAGMENT_COUNT_FOR_COC_CHOICE', 3)
     end
 
     def add_projects_with_coc(coc_code, count)
@@ -731,19 +731,21 @@ RSpec.describe model, type: :model do
     end
 
     it 'does not require a choice for a large data source with a single CoC' do
-      add_projects_with_coc('XX-500', 5)
+      add_projects_with_coc('XX-500', 7)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
-    it 'does not require a choice under the size threshold, even when fragmented' do
+    it 'does not require a choice under the size threshold when the fragment and dominance rules would require one' do
+      # 2/2/1: 3 fragment projects and 40% dominance, but only 5 projects.
       add_projects_with_coc('XX-500', 2)
-      add_projects_with_coc('XX-502', 1)
+      add_projects_with_coc('XX-502', 2)
+      add_projects_with_coc('XX-503', 1)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
     it 'does not require a choice when the non-dominant fragments total under the fragment threshold' do
-      # 2/1/1: at the size gate and only 50% dominant, but the two fragments together are under 3.
-      add_projects_with_coc('XX-500', 2)
+      # 4/1/1: at the size gate and 66.7% dominant, but only 2 fragment projects.
+      add_projects_with_coc('XX-500', 4)
       add_projects_with_coc('XX-502', 1)
       add_projects_with_coc('XX-503', 1)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
@@ -763,8 +765,25 @@ RSpec.describe model, type: :model do
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
+    it 'counts a project once in a CoC no matter how many ProjectCoc rows it has there' do
+      # 8/2 by project, 8/3 by ProjectCoc row: only row counting would reach the fragment gate.
+      add_projects_with_coc('XX-500', 8)
+      duplicated, _single = add_projects_with_coc('XX-502', 2)
+      create(:hud_project_coc, data_source_id: ds.id, ProjectID: duplicated.ProjectID, CoCCode: 'XX-502')
+      expect(ds.require_coc_choice?(all_projects)).to eq(false)
+    end
+
+    it 'counts a project in each CoC it belongs to' do
+      # 8 projects, 3 of them in both CoCs: 8/3 by CoC, so a choice is required.
+      projects = add_projects_with_coc('XX-500', 8)
+      projects.first(3).each do |project|
+        create(:hud_project_coc, data_source_id: ds.id, ProjectID: project.ProjectID, CoCCode: 'XX-502')
+      end
+      expect(ds.require_coc_choice?(all_projects)).to eq(true)
+    end
+
     it 'does not require a choice when there is no CoC data at all' do
-      create_list(:hud_project, 5, data_source_id: ds.id, OrganizationID: org.OrganizationID)
+      create_list(:hud_project, 7, data_source_id: ds.id, OrganizationID: org.OrganizationID)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
@@ -780,14 +799,14 @@ RSpec.describe model, type: :model do
       expect(ds.require_coc_choice?(restricted_scope)).to eq(false)
     end
 
-    it 'treats nil, empty, and whitespace-only CoC codes as a single dominance bucket' do
+    it 'groups nil, empty, and whitespace-only CoC codes into one bucket' do
       add_projects_with_coc('XX-500', 1)
-      add_projects_with_coc(nil, 1)
-      add_projects_with_coc('', 1)
+      add_projects_with_coc(nil, 2)
+      add_projects_with_coc('', 2)
       add_projects_with_coc('   ', 1)
-      # Grouped as one "unknown" bucket: two buckets with a single fragment project, so no choice
-      # is needed. If nil/''/'   ' were instead counted as three separate one-project buckets, there
-      # would be 3 fragment projects and 25% dominance, and a choice would wrongly be required.
+      # Grouped as one "unknown" bucket: 5/1 with a single fragment project, so no choice is
+      # needed. If nil/''/'   ' were instead counted as three separate buckets, there would be
+      # 4 fragment projects and 33% dominance, and a choice would wrongly be required.
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
   end

--- a/spec/models/grda_warehouse/data_source_spec.rb
+++ b/spec/models/grda_warehouse/data_source_spec.rb
@@ -716,50 +716,67 @@ RSpec.describe model, type: :model do
     let!(:org) { create(:hud_organization, data_source_id: ds.id) }
     let(:all_projects) { GrdaWarehouse::Hud::Project.all }
 
+    # Small thresholds keep fixtures cheap while still letting each rule be crossed independently:
+    # with 4 total and 3 fragments, a source can be at the size gate with fragments under the
+    # fragment gate (2/1/1) while still being under the dominance threshold.
+    before do
+      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_PROJECT_COUNT', 4)
+      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_FRAGMENT_COUNT', 3)
+    end
+
     def add_projects_with_coc(coc_code, count)
       create_list(:hud_project, count, data_source_id: ds.id, OrganizationID: org.OrganizationID).each do |project|
         create(:hud_project_coc, data_source_id: ds.id, ProjectID: project.ProjectID, CoCCode: coc_code)
       end
     end
 
-    it 'does not require a choice when one CoC has exactly the dominance threshold share' do
-      add_projects_with_coc('XX-500', 3)
+    it 'does not require a choice for a large data source with a single CoC' do
+      add_projects_with_coc('XX-500', 5)
+      expect(ds.require_coc_choice?(all_projects)).to eq(false)
+    end
+
+    it 'does not require a choice under the size threshold, even when fragmented' do
+      add_projects_with_coc('XX-500', 2)
       add_projects_with_coc('XX-502', 1)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
-    it 'requires a choice when just under the dominance threshold' do
+    it 'does not require a choice when the non-dominant fragments total under the fragment threshold' do
+      # 2/1/1: at the size gate and only 50% dominant, but the two fragments together are under 3.
       add_projects_with_coc('XX-500', 2)
       add_projects_with_coc('XX-502', 1)
+      add_projects_with_coc('XX-503', 1)
+      expect(ds.require_coc_choice?(all_projects)).to eq(false)
+    end
+
+    it 'requires a choice when large, fragmented at the fragment threshold, and under the dominance threshold' do
+      # 8/3 =~ 72.7% dominance with exactly 3 fragment projects.
+      add_projects_with_coc('XX-500', 8)
+      add_projects_with_coc('XX-502', 3)
       expect(ds.require_coc_choice?(all_projects)).to eq(true)
     end
 
-    it 'requires a choice once project count reaches the size threshold, even when fully concentrated' do
-      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_PROJECT_COUNT', 3)
-      add_projects_with_coc('XX-500', 3)
-      expect(ds.require_coc_choice?(all_projects)).to eq(true)
-    end
-
-    it 'does not require a choice just under the size threshold when fully concentrated' do
-      stub_const('GrdaWarehouse::DataSource::SMALL_ENOUGH_PROJECT_COUNT', 3)
-      add_projects_with_coc('XX-500', 2)
+    it 'does not require a choice when one CoC has exactly the dominance threshold share' do
+      # 9/3 = 75%.
+      add_projects_with_coc('XX-500', 9)
+      add_projects_with_coc('XX-502', 3)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
     it 'does not require a choice when there is no CoC data at all' do
-      create_list(:hud_project, 3, data_source_id: ds.id, OrganizationID: org.OrganizationID)
+      create_list(:hud_project, 5, data_source_id: ds.id, OrganizationID: org.OrganizationID)
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
 
     it 'only counts CoC data for projects included in the given project scope' do
-      add_projects_with_coc('XX-500', 2)
-      add_projects_with_coc('XX-502', 1)
-      # Unscoped: 2/3 =~ 66.7% dominance, under the 75% threshold, so a choice is required.
+      add_projects_with_coc('XX-500', 8)
+      add_projects_with_coc('XX-502', 3)
+      # Unscoped: 8/11 =~ 72.7% dominance, under the 75% threshold, so a choice is required.
       expect(ds.require_coc_choice?(all_projects)).to eq(true)
 
       visible_project_ids = GrdaWarehouse::Hud::ProjectCoc.where(data_source_id: ds.id, CoCCode: 'XX-500').pluck(:ProjectID)
       restricted_scope = GrdaWarehouse::Hud::Project.where(data_source_id: ds.id, ProjectID: visible_project_ids)
-      # Restricted to only the projects with a visible CoC: fully concentrated, so no choice is needed.
+      # Restricted to only the projects with a visible CoC: a single bucket, so no choice is needed.
       expect(ds.require_coc_choice?(restricted_scope)).to eq(false)
     end
 
@@ -768,10 +785,9 @@ RSpec.describe model, type: :model do
       add_projects_with_coc(nil, 1)
       add_projects_with_coc('', 1)
       add_projects_with_coc('   ', 1)
-      # Grouped as one "unknown" bucket: 3/4 = 75%, meeting the threshold, so no choice is needed.
-      # If nil/''/'   ' were instead counted as three separate one-project buckets, the largest
-      # bucket would be XX-500 with 1/4 = 25%, well under the threshold, and a choice would wrongly
-      # be required.
+      # Grouped as one "unknown" bucket: two buckets with a single fragment project, so no choice
+      # is needed. If nil/''/'   ' were instead counted as three separate one-project buckets, there
+      # would be 3 fragment projects and 25% dominance, and a choice would wrongly be required.
       expect(ds.require_coc_choice?(all_projects)).to eq(false)
     end
   end

--- a/spec/requests/data_sources_controller_spec.rb
+++ b/spec/requests/data_sources_controller_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe DataSourcesController, type: :request do
       collection.set_viewables({ data_sources: [data_source.id] })
       setup_access_control(user, role, collection)
       sign_in user
+      # Thresholds low enough that a handful of projects decides the CoC picker on
+      # fragmentation and dominance alone.
+      stub_const('GrdaWarehouse::DataSource::MIN_PROJECT_COUNT_FOR_COC_CHOICE', 2)
+      stub_const('GrdaWarehouse::DataSource::MIN_FRAGMENT_COUNT_FOR_COC_CHOICE', 1)
     end
 
     context 'when the data source has more than two CoC codes' do
@@ -153,7 +157,7 @@ RSpec.describe DataSourcesController, type: :request do
       end
     end
 
-    context 'when the data source is small and one CoC dominates' do
+    context 'when one CoC holds the dominance share' do
       let!(:org) { create(:hud_organization, data_source: data_source, OrganizationName: 'Dominant Coc Org') }
       let!(:project_one) do
         create(:hud_project, data_source: data_source, OrganizationID: org.OrganizationID, ProjectName: 'First Dominant Coc Project')
@@ -184,7 +188,7 @@ RSpec.describe DataSourcesController, type: :request do
       end
     end
 
-    context 'when the data source is small but CoC codes are evenly split' do
+    context 'when CoC codes are evenly split' do
       let!(:org) { create(:hud_organization, data_source: data_source, OrganizationName: 'Split Coc Org') }
       let!(:project_one) do
         create(:hud_project, data_source: data_source, OrganizationID: org.OrganizationID, ProjectName: 'First Split Coc Project')


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`


## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adjusts the logic used to determine when to show drill-downs to CoCs on the Data Source show page
* Specifically attempts to keep the projects on the main page if there is very little fragmentation or if there is only one CoC

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* Bug fix

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

