### PR TITLE
HMIS CSV Splitter - split into N roughly equal parts

### DIFF
--- a/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
+++ b/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
@@ -18,8 +18,22 @@
 #
 # Checking the results: each entry has the source row count, the rows written across all parts, and
 # the per-part breakdown. With no project_ids filter, original - added is 0 for every file except
-# Client.csv, where a client enrolled in projects that landed in different parts is written to each.
-#   splitter.results.transform_values { |r| r[:original] - r[:added] }
+# Client.csv and Organization.csv.
+# A client enrolled in projects that landed in different parts is written to each.
+# An Organization with projects that landed in different parts is written to each.
+#
+# splitter.results.transform_values { |r| r[:original] - r[:added] }
+#
+# To confirm client and organization counts, the following should output the numbers in the initial files:
+#
+# destination_path = '/path/to/destination'
+# %w[Organization.csv Client.csv].each do |filename|
+#   column = filename == 'Client.csv' ? 'PersonalID' : 'OrganizationID'
+#   ids = (1..5).flat_map do |i|
+#     CSV.read(File.join(destination_path, "part_#{i}", filename), headers: true).map { |r| r[column] }
+#   end
+#   puts "#{filename}: #{ids.uniq.size} distinct ids across parts"
+# end
 
 require 'csv'
 

--- a/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
+++ b/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
@@ -10,6 +10,10 @@
 # Run like so:
 # splitter = GrdaWarehouse::Tasks::HmisCsvSplitter.new(source_path: '/path/to/source/data', destination_path: '/path/to/destination/data', project_ids: ['P-1', 'P-2', 'P-3'])
 # splitter.run!
+#
+# To split into N parts with roughly even enrollment counts (writes destination/part_1 .. part_N):
+# splitters = GrdaWarehouse::Tasks::HmisCsvSplitter.split_evenly(source_path: '/path/to/source/data', destination_path: '/path/to/destination', parts: 3)
+# splitters.sum { |s| s.results['Enrollment.csv'][:added] } # should equal splitters.first.results['Enrollment.csv'][:original]
 
 ###  Checking the results:
 ### if you split the file into two and ran `splitter` and `splitter2`
@@ -40,6 +44,62 @@ module GrdaWarehouse::Tasks
       @unenrolled_clients_personal_ids = Set.new
       @results = {}
       self.include_unenrolled_clients = include_unenrolled_clients
+    end
+
+    # Splits the source into `parts` file sets under destination_path/part_1 .. part_N, grouping
+    # projects so enrollment counts are roughly even across parts. Unenrolled clients, when
+    # requested, are written to part_1 only so no Client.csv row appears in more than one part.
+    # Returns the splitters, one per part, after each has run.
+    def self.split_evenly(source_path:, destination_path:, parts:, include_unenrolled_clients: false)
+      raise ArgumentError, "parts must be a positive Integer, got #{parts.inspect}" unless parts.is_a?(Integer) && parts.positive?
+
+      groups = balance_projects(project_enrollment_counts(source_path), parts)
+      groups.each_with_index.map do |project_ids, index|
+        splitter = new(
+          source_path: source_path,
+          destination_path: File.join(destination_path, "part_#{index + 1}"),
+          project_ids: project_ids,
+          include_unenrolled_clients: include_unenrolled_clients && index.zero?,
+        )
+        splitter.run!
+        splitter
+      end
+    end
+
+    # Greedy longest-processing-time assignment: largest project first, each into the part
+    # with the smallest running enrollment total. Ties fall to the part with fewer projects,
+    # then the lower index, so equal inputs always produce the same grouping.
+    def self.balance_projects(enrollment_counts, parts)
+      buckets = Array.new(parts) { { total: 0, project_ids: [] } }
+      ordered = enrollment_counts.sort_by { |project_id, count| [-count, project_id] }
+      ordered.each do |project_id, count|
+        bucket = buckets.each_with_index.min_by { |b, i| [b[:total], b[:project_ids].size, i] }.first
+        bucket[:project_ids] << project_id
+        bucket[:total] += count
+      end
+      buckets.map { |b| b[:project_ids] }
+    end
+
+    def self.project_enrollment_counts(source_path)
+      counts = Hash.new(0)
+      each_source_row(File.join(source_path, 'Project.csv')) do |row|
+        # Registers the key at 0 so projects with no enrollments still appear in the hash.
+        counts[row['ProjectID']] += 0
+      end
+      each_source_row(File.join(source_path, 'Enrollment.csv')) do |row|
+        counts[row['ProjectID']] += 1
+      end
+      counts
+    end
+
+    def self.each_source_row(source_file_path, &block)
+      open_source_csv(source_file_path) { |csv| csv.each(&block) }
+    end
+
+    # HMIS CSVs come in all sorts of encodings.
+    # Detect the source's actual encoding (BOM or statistical) and eventually writes it out as UTF-8.
+    def self.open_source_csv(source_file_path, headers: true, &block)
+      AutoEncodingCsv.open(source_file_path, headers: headers, liberal_parsing: true, &block)
     end
 
     def run!
@@ -150,13 +210,11 @@ module GrdaWarehouse::Tasks
     end
 
     private def each_source_row(source_file_path, &block)
-      open_source_csv(source_file_path) { |csv| csv.each(&block) }
+      self.class.each_source_row(source_file_path, &block)
     end
 
-    # HMIS CSVs come in all sorts of encodings.
-    # Detect the source's actual encoding (BOM or statistical) and eventually writes it out as UTF-8.
     private def open_source_csv(source_file_path, headers: true, &block)
-      AutoEncodingCsv.open(source_file_path, headers: headers, liberal_parsing: true, &block)
+      self.class.open_source_csv(source_file_path, headers: headers, &block)
     end
 
     private def manually_processed

--- a/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
+++ b/app/models/grda_warehouse/tasks/hmis_csv_splitter.rb
@@ -6,64 +6,70 @@
 
 # frozen_string_literal: true
 
-# This class is used to split HMIS data into multiple file sets based on the project ids provided
-# Run like so:
-# splitter = GrdaWarehouse::Tasks::HmisCsvSplitter.new(source_path: '/path/to/source/data', destination_path: '/path/to/destination/data', project_ids: ['P-1', 'P-2', 'P-3'])
-# splitter.run!
+# Splits an HMIS CSV export into N importable file sets under destination_path/part_1 .. part_N,
+# grouping projects so enrollment counts are roughly even across parts.
 #
-# To split into N parts with roughly even enrollment counts (writes destination/part_1 .. part_N):
-# splitters = GrdaWarehouse::Tasks::HmisCsvSplitter.split_evenly(source_path: '/path/to/source/data', destination_path: '/path/to/destination', parts: 3)
-# splitters.sum { |s| s.results['Enrollment.csv'][:added] } # should equal splitters.first.results['Enrollment.csv'][:original]
-
-###  Checking the results:
-### if you split the file into two and ran `splitter` and `splitter2`
-# missing = {}
-# splitter.results.each do |filename, result|
-#   missing[filename] = {}
-#   processed_count = splitter.results[filename][:added] + splitter2.results[filename][:added]
-#   missing[filename][:missing] = result[:original] - processed_count
-#   missing[filename][:original] = result[:original]
-# end
-# missing
-### NOTE: negative numbers mean they were in both files
+# Split everything into three balanced parts:
+#   splitter = GrdaWarehouse::Tasks::HmisCsvSplitter.new(source_path: '/path/to/source', destination_path: '/path/to/destination', parts: 3)
+#   splitter.run!
+#
+# Extract two projects into a single file set (written to destination/part_1):
+#   GrdaWarehouse::Tasks::HmisCsvSplitter.new(source_path: '/path/to/source', destination_path: '/path/to/destination', project_ids: ['P-1', 'P-2'], parts: 1).run!
+#
+# Checking the results: each entry has the source row count, the rows written across all parts, and
+# the per-part breakdown. With no project_ids filter, original - added is 0 for every file except
+# Client.csv, where a client enrolled in projects that landed in different parts is written to each.
+#   splitter.results.transform_values { |r| r[:original] - r[:added] }
 
 require 'csv'
-require 'memery'
 
 module GrdaWarehouse::Tasks
   class HmisCsvSplitter
-    include Memery
-    attr_accessor :project_ids, :enrollment_ids, :personal_ids, :export_id, :source_path, :destination_path, :organization_ids, :results, :unenrolled_clients_personal_ids, :include_unenrolled_clients
-    def initialize(source_path:, destination_path:, project_ids:, include_unenrolled_clients: false)
-      @source_path = source_path
-      @destination_path = destination_path
-      @project_ids = project_ids
-      @organization_ids = Set.new
-      @enrollment_ids = Set.new
-      @personal_ids = Set.new
-      @unenrolled_clients_personal_ids = Set.new
-      @results = {}
-      self.include_unenrolled_clients = include_unenrolled_clients
-    end
+    attr_reader :source_path, :destination_path, :parts, :project_ids, :include_unenrolled_clients, :results, :project_groups
 
-    # Splits the source into `parts` file sets under destination_path/part_1 .. part_N, grouping
-    # projects so enrollment counts are roughly even across parts. Unenrolled clients, when
-    # requested, are written to part_1 only so no Client.csv row appears in more than one part.
-    # Returns the splitters, one per part, after each has run.
-    def self.split_evenly(source_path:, destination_path:, parts:, include_unenrolled_clients: false)
+    # project_ids: nil processes every project; an Array restricts the split to those projects and
+    # drops rows for any other ProjectID, including enrollments whose project is not in Project.csv.
+    def initialize(source_path:, destination_path:, parts: 1, project_ids: nil, include_unenrolled_clients: false)
       raise ArgumentError, "parts must be a positive Integer, got #{parts.inspect}" unless parts.is_a?(Integer) && parts.positive?
 
-      groups = balance_projects(project_enrollment_counts(source_path), parts)
-      groups.each_with_index.map do |project_ids, index|
-        splitter = new(
-          source_path: source_path,
-          destination_path: File.join(destination_path, "part_#{index + 1}"),
-          project_ids: project_ids,
-          include_unenrolled_clients: include_unenrolled_clients && index.zero?,
-        )
-        splitter.run!
-        splitter
+      @source_path = source_path
+      @destination_path = destination_path
+      @parts = parts
+      @project_ids = project_ids
+      @project_filter = project_ids&.to_set
+      @include_unenrolled_clients = include_unenrolled_clients
+      @results = {}
+      @project_groups = []
+      @part_for_project = {}
+      @parts_for_organization = {}
+      @part_for_enrollment = {}
+      @parts_for_personal_id = {}
+    end
+
+    def run!
+      return unless source_path.present? && File.directory?(source_path)
+
+      Rails.logger.debug "Processing HMIS data from #{source_path}"
+      build_routing_tables
+      part_paths.each do |path|
+        FileUtils.mkdir_p(path)
+        manually_processed.each { |filename| FileUtils.cp(File.join(source_path, filename), path) }
       end
+
+      HmisCsvTwentyTwentySix.importable_files_map.each_key do |filename|
+        next if filename.in?(manually_processed)
+
+        source_file_path = File.join(source_path, filename)
+        unless File.exist?(source_file_path)
+          Rails.logger.debug "Skipping #{filename}, does not exist in source path"
+          next
+        end
+
+        Rails.logger.debug "Splitting #{filename}"
+        split_file(filename, source_file_path)
+        Rails.logger.debug "Added #{results[filename][:added]} of #{results[filename][:original]} rows to #{filename} by part: #{results[filename][:by_part]}"
+      end
+      results
     end
 
     # Greedy longest-processing-time assignment: largest project first, each into the part
@@ -80,127 +86,94 @@ module GrdaWarehouse::Tasks
       buckets.map { |b| b[:project_ids] }
     end
 
-    def self.project_enrollment_counts(source_path)
+    # Reads Project.csv once and Enrollment.csv twice: the first enrollment pass counts per project so
+    # the projects can be balanced, the second assigns each enrollment and client to a part.
+    private def build_routing_tables
+      organization_by_project = {}
       counts = Hash.new(0)
       each_source_row(File.join(source_path, 'Project.csv')) do |row|
-        # Registers the key at 0 so projects with no enrollments still appear in the hash.
+        next unless included_project?(row['ProjectID'])
+
+        organization_by_project[row['ProjectID']] = row['OrganizationID']
+        # Registers the key at 0 so projects with no enrollments still get a part.
         counts[row['ProjectID']] += 0
       end
       each_source_row(File.join(source_path, 'Enrollment.csv')) do |row|
-        counts[row['ProjectID']] += 1
-      end
-      counts
-    end
-
-    def self.each_source_row(source_file_path, &block)
-      open_source_csv(source_file_path) { |csv| csv.each(&block) }
-    end
-
-    # HMIS CSVs come in all sorts of encodings.
-    # Detect the source's actual encoding (BOM or statistical) and eventually writes it out as UTF-8.
-    def self.open_source_csv(source_file_path, headers: true, &block)
-      AutoEncodingCsv.open(source_file_path, headers: headers, liberal_parsing: true, &block)
-    end
-
-    def run!
-      return unless source_path.present? && File.directory?(source_path)
-
-      Rails.logger.debug "Processing HMIS data from #{source_path}"
-      # Copy Export.csv
-      FileUtils.mkdir_p(destination_path)
-      Rails.logger.debug 'Copying Export.csv'
-      FileUtils.cp_r(File.join(source_path, 'Export.csv'), destination_path)
-      Rails.logger.debug 'Copying User.csv'
-      FileUtils.cp_r(File.join(source_path, 'User.csv'), destination_path)
-      Rails.logger.debug 'Finding relevant organizations'
-      capture_relevant_organization_ids
-      Rails.logger.debug 'Finding relevant enrollment ids'
-      capture_relevant_enrollment_ids
-      if include_unenrolled_clients
-        Rails.logger.debug 'Finding unenrolled clients'
-        capture_unenrolled_clients
-        Rails.logger.debug "Found #{unenrolled_clients_personal_ids.size} unenrolled clients"
+        counts[row['ProjectID']] += 1 if included_project?(row['ProjectID'])
       end
 
-      HmisCsvTwentyTwentySix.importable_files_map.each_key do |filename|
-        next if filename.in?(manually_processed)
-
-        Rails.logger.debug "Splitting #{filename}"
-        source_file_path = File.join(source_path, filename)
-        destination_file_path = File.join(destination_path, filename)
-        unless File.exist?(source_file_path)
-          Rails.logger.debug "Skipping #{filename}, does not exist in source path"
-          next
+      @project_groups = self.class.balance_projects(counts, parts)
+      project_groups.each_with_index do |ids, part|
+        ids.each do |project_id|
+          @part_for_project[project_id] = part
+          organization_id = organization_by_project[project_id]
+          add_part(@parts_for_organization, organization_id, part) if organization_id
         end
-
-        results[filename] = { added: 0, original: 0 }
-        headers = source_headers(source_file_path)
-        raise "Headers are blank for #{filename}" if headers.blank?
-
-        ::CSV.open(destination_file_path, 'wb') do |output|
-          output << headers
-          each_source_row(source_file_path) do |row|
-            results[filename][:original] += 1
-            # Add project limited
-            if filename.in?(project_related)
-              if row['ProjectID'].in?(project_ids)
-                output << row
-                results[filename][:added] += 1
-              end
-            elsif filename == 'Organization.csv'
-              if row['OrganizationID'].in?(organization_ids)
-                output << row
-                results[filename][:added] += 1
-              end
-            elsif filename == 'Client.csv'
-              if row['PersonalID'].in?(personal_ids) || row['PersonalID'].in?(unenrolled_clients_personal_ids)
-                output << row
-                results[filename][:added] += 1
-              end
-            else
-              # Add enrollment limited
-              if row['EnrollmentID'].in?(enrollment_ids)
-                output << row
-                results[filename][:added] += 1
-              end
-            end
-          end
-        end
-        Rails.logger.debug "Added #{results[filename][:added]} of #{results[filename][:original]} rows to #{filename}"
       end
-      results
-    end
 
-    # Find relevant OrganizationIDs in Project.csv and make note
-    private def capture_relevant_organization_ids
-      each_source_row(File.join(source_path, 'Project.csv')) do |row|
-        next unless row['ProjectID'].in?(project_ids)
-
-        organization_ids << row['OrganizationID']
-      end
-    end
-
-    # Find relevant EnrollmentID and PersonalIDs in Enrollment.csv and make note
-    private def capture_relevant_enrollment_ids
+      enrolled_personal_ids = Set.new
       each_source_row(File.join(source_path, 'Enrollment.csv')) do |row|
-        next unless row['ProjectID'].in?(project_ids)
+        enrolled_personal_ids << row['PersonalID'] if include_unenrolled_clients
+        part = @part_for_project[row['ProjectID']]
+        next if part.nil?
 
-        enrollment_ids << row['EnrollmentID']
-        personal_ids << row['PersonalID']
+        @part_for_enrollment[row['EnrollmentID']] = part
+        add_part(@parts_for_personal_id, row['PersonalID'], part)
       end
+
+      capture_unenrolled_clients(enrolled_personal_ids) if include_unenrolled_clients
     end
 
-    private def capture_unenrolled_clients
-      all_enrolled_clients = Set.new
-      each_source_row(File.join(source_path, 'Enrollment.csv')) do |row|
-        all_enrolled_clients.add(row['PersonalID'])
-      end
-
+    # A client with no enrollment anywhere in the source, filter or not, is written to part 1 only.
+    private def capture_unenrolled_clients(enrolled_personal_ids)
       each_source_row(File.join(source_path, 'Client.csv')) do |row|
-        next if all_enrolled_clients.include?(row['PersonalID'])
+        next if enrolled_personal_ids.include?(row['PersonalID'])
 
-        unenrolled_clients_personal_ids.add(row['PersonalID'])
+        add_part(@parts_for_personal_id, row['PersonalID'], 0)
       end
+    end
+
+    private def split_file(filename, source_file_path)
+      results[filename] = { original: 0, added: 0, by_part: Array.new(parts, 0) }
+      headers = source_headers(source_file_path)
+      raise "Headers are blank for #{filename}" if headers.blank?
+
+      outputs = part_paths.map { |path| ::CSV.open(File.join(path, filename), 'wb') }
+      outputs.each { |output| output << headers }
+      each_source_row(source_file_path) do |row|
+        results[filename][:original] += 1
+        target_parts(filename, row).each do |part|
+          outputs[part] << row
+          results[filename][:added] += 1
+          results[filename][:by_part][part] += 1
+        end
+      end
+    ensure
+      outputs&.each(&:close)
+    end
+
+    private def target_parts(filename, row)
+      if filename.in?(project_related)
+        Array(@part_for_project[row['ProjectID']])
+      elsif filename == 'Organization.csv'
+        @parts_for_organization[row['OrganizationID']] || []
+      elsif filename == 'Client.csv'
+        @parts_for_personal_id[row['PersonalID']] || []
+      else
+        Array(@part_for_enrollment[row['EnrollmentID']])
+      end
+    end
+
+    private def add_part(table, key, part)
+      (table[key] ||= Set.new) << part
+    end
+
+    private def included_project?(project_id)
+      @project_filter.nil? || @project_filter.include?(project_id)
+    end
+
+    private def part_paths
+      @part_paths ||= (1..parts).map { |i| File.join(destination_path, "part_#{i}") }
     end
 
     # Headers can't come from the data rows; a source file may legitimately contain only a header
@@ -210,11 +183,13 @@ module GrdaWarehouse::Tasks
     end
 
     private def each_source_row(source_file_path, &block)
-      self.class.each_source_row(source_file_path, &block)
+      open_source_csv(source_file_path) { |csv| csv.each(&block) }
     end
 
+    # HMIS CSVs come in all sorts of encodings.
+    # Detect the source's actual encoding (BOM or statistical) and eventually writes it out as UTF-8.
     private def open_source_csv(source_file_path, headers: true, &block)
-      self.class.open_source_csv(source_file_path, headers: headers, &block)
+      AutoEncodingCsv.open(source_file_path, headers: headers, liberal_parsing: true, &block)
     end
 
     private def manually_processed

--- a/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
+++ b/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
@@ -1,0 +1,196 @@
+###
+# Copyright Green River Data Group, Inc.
+#
+# License detail: https://github.com/greenriver/hmis-warehouse/blob/production/LICENSE.md
+###
+
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
+  let(:source_path) { Dir.mktmpdir('splitter-source') }
+  let(:destination_path) { Dir.mktmpdir('splitter-dest') }
+
+  after do
+    FileUtils.rm_rf(source_path)
+    FileUtils.rm_rf(destination_path)
+  end
+
+  def write_csv(dir, filename, headers, rows)
+    CSV.open(File.join(dir, filename), 'wb') do |csv|
+      csv << headers
+      rows.each { |row| csv << row }
+    end
+  end
+
+  def read_column(path, column)
+    CSV.read(path, headers: true).map { |row| row[column] }
+  end
+
+  describe '.balance_projects' do
+    it 'isolates a dominant project and pairs the remaining projects across the other parts' do
+      counts = { 'P1' => 75, 'P2' => 6, 'P3' => 6, 'P4' => 7, 'P5' => 6 }
+
+      groups = described_class.balance_projects(counts, 3)
+
+      expect(groups.size).to eq(3)
+      expect(groups).to include(['P1'])
+      small_groups = groups.reject { |g| g == ['P1'] }
+      expect(small_groups.map(&:size)).to eq([2, 2])
+      expect(small_groups.flatten).to contain_exactly('P2', 'P3', 'P4', 'P5')
+    end
+
+    it 'assigns each project to the part with the smallest running enrollment total' do
+      counts = { 'A' => 10, 'B' => 8, 'C' => 7, 'D' => 5 }
+
+      groups = described_class.balance_projects(counts, 2)
+
+      # LPT order: A->part1 (10), B->part2 (8), C->part2 (15), D->part1 (15)
+      expect(groups).to eq([['A', 'D'], ['B', 'C']])
+    end
+
+    it 'places projects with zero enrollments into the part with the smallest total' do
+      counts = { 'BIG' => 20, 'Z1' => 0, 'Z2' => 0 }
+
+      groups = described_class.balance_projects(counts, 2)
+
+      expect(groups).to eq([['BIG'], ['Z1', 'Z2']])
+    end
+
+    it 'returns exactly the requested number of parts, leaving later parts empty when projects run out' do
+      groups = described_class.balance_projects({ 'P1' => 3 }, 3)
+
+      expect(groups).to eq([['P1'], [], []])
+    end
+
+    it 'breaks ties by project id so the grouping is deterministic regardless of hash order' do
+      forward = described_class.balance_projects({ 'X' => 5, 'Y' => 5, 'W' => 5 }, 2)
+      reversed = described_class.balance_projects({ 'W' => 5, 'Y' => 5, 'X' => 5 }, 2)
+
+      expect(forward).to eq([['W', 'Y'], ['X']])
+      expect(reversed).to eq(forward)
+    end
+  end
+
+  describe '.project_enrollment_counts' do
+    it 'counts enrollments per ProjectID, including zero for projects with none and projects only seen in Enrollment.csv' do
+      projects = [
+        ['P1', 'O1', 'One'],
+        ['P2', 'O1', 'Two'],
+        ['EMPTY', 'O2', 'No enrollments'],
+      ]
+      enrollments = [
+        ['E1', 'C1', 'P1'],
+        ['E2', 'C2', 'P1'],
+        ['E3', 'C3', 'P2'],
+        ['E4', 'C4', 'ORPHAN'],
+      ]
+      write_csv(source_path, 'Project.csv', ['ProjectID', 'OrganizationID', 'ProjectName'], projects)
+      write_csv(source_path, 'Enrollment.csv', ['EnrollmentID', 'PersonalID', 'ProjectID'], enrollments)
+
+      counts = described_class.project_enrollment_counts(source_path)
+
+      expect(counts).to eq('P1' => 2, 'P2' => 1, 'EMPTY' => 0, 'ORPHAN' => 1)
+    end
+  end
+
+  describe '.split_evenly' do
+    # 6 projects: P1 holds 12 of 16 enrollments, P2..P5 hold 1 each, P6 has none.
+    # Expected grouping for 3 parts: [P1], [P2, P4, P6], [P3, P5].
+    let(:projects) do
+      [['P1', 'O1'], ['P2', 'O1'], ['P3', 'O2'], ['P4', 'O2'], ['P5', 'O2'], ['P6', 'O3']]
+    end
+    let(:enrollments) do
+      p1 = (1..12).map { |i| ["E1-#{i}", "C1-#{i}", 'P1'] }
+      p1 + [['E2', 'C2', 'P2'], ['E3', 'C3', 'P3'], ['E4', 'C4', 'P4'], ['E5', 'C5', 'P5']]
+    end
+    let(:enrolled_client_ids) { enrollments.map { |row| row[1] } }
+
+    before do
+      write_csv(source_path, 'Export.csv', ['ExportID', 'SourceType'], [['EX1', '3']])
+      write_csv(source_path, 'User.csv', ['UserID', 'UserFirstName'], [['U1', 'Pat']])
+      write_csv(source_path, 'Organization.csv', ['OrganizationID', 'OrganizationName'], [['O1', 'One'], ['O2', 'Two'], ['O3', 'Three']])
+      write_csv(source_path, 'Project.csv', ['ProjectID', 'OrganizationID', 'ProjectName'], projects.map { |id, org| [id, org, id] })
+      write_csv(source_path, 'Enrollment.csv', ['EnrollmentID', 'PersonalID', 'ProjectID'], enrollments)
+      write_csv(source_path, 'Client.csv', ['PersonalID', 'FirstName'], (enrolled_client_ids + ['UNENROLLED']).map { |id| [id, id] })
+      write_csv(source_path, 'Exit.csv', ['ExitID', 'EnrollmentID', 'PersonalID'], enrollments.map { |e, c, _| ["X-#{e}", e, c] })
+    end
+
+    def part_dir(index)
+      File.join(destination_path, "part_#{index}")
+    end
+
+    it 'writes one directory per part with the dominant project alone and the rest balanced' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      expect(Dir.children(destination_path)).to contain_exactly('part_1', 'part_2', 'part_3')
+      expect(read_column(File.join(part_dir(1), 'Project.csv'), 'ProjectID')).to contain_exactly('P1')
+      expect(read_column(File.join(part_dir(2), 'Project.csv'), 'ProjectID')).to contain_exactly('P2', 'P4', 'P6')
+      expect(read_column(File.join(part_dir(3), 'Project.csv'), 'ProjectID')).to contain_exactly('P3', 'P5')
+    end
+
+    it 'partitions enrollment-scoped rows so every source row appears in exactly one part' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      enrollment_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Enrollment.csv'), 'EnrollmentID') }
+      exit_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Exit.csv'), 'EnrollmentID') }
+
+      expect(enrollment_ids_by_part.flatten).to contain_exactly(*enrollments.map(&:first))
+      expect(enrollment_ids_by_part.map(&:size)).to eq([12, 2, 2])
+      expect(exit_ids_by_part).to eq(enrollment_ids_by_part)
+    end
+
+    it 'limits Organization.csv in each part to the organizations of that part\'s projects' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      expect(read_column(File.join(part_dir(1), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O1')
+      expect(read_column(File.join(part_dir(2), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O1', 'O2', 'O3')
+      expect(read_column(File.join(part_dir(3), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O2')
+    end
+
+    it 'copies Export.csv and User.csv unchanged into every part' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      (1..3).each do |i|
+        expect(File.read(File.join(part_dir(i), 'Export.csv'))).to eq(File.read(File.join(source_path, 'Export.csv')))
+        expect(File.read(File.join(part_dir(i), 'User.csv'))).to eq(File.read(File.join(source_path, 'User.csv')))
+      end
+    end
+
+    it 'excludes unenrolled clients from every part by default' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      client_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Client.csv'), 'PersonalID') }
+
+      expect(client_ids_by_part.flatten).to contain_exactly(*enrolled_client_ids)
+    end
+
+    it 'adds unenrolled clients to part 1 only when include_unenrolled_clients is true' do
+      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3, include_unenrolled_clients: true)
+
+      client_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Client.csv'), 'PersonalID') }
+
+      expect(client_ids_by_part[0]).to include('UNENROLLED')
+      expect(client_ids_by_part[1]).not_to include('UNENROLLED')
+      expect(client_ids_by_part[2]).not_to include('UNENROLLED')
+      expect(client_ids_by_part.flatten).to contain_exactly(*enrolled_client_ids, 'UNENROLLED')
+    end
+
+    it 'returns one run splitter per part so results can be reconciled against the source' do
+      splitters = described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+
+      expect(splitters.map(&:project_ids)).to eq([['P1'], ['P2', 'P4', 'P6'], ['P3', 'P5']])
+      added = splitters.sum { |s| s.results['Enrollment.csv'][:added] }
+      expect(added).to eq(enrollments.size)
+      expect(splitters.first.results['Enrollment.csv'][:original]).to eq(enrollments.size)
+    end
+
+    it 'raises ArgumentError when parts is not a positive integer' do
+      expect { described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 0) }.
+        to raise_error(ArgumentError, /parts/)
+      expect { described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: '3') }.
+        to raise_error(ArgumentError, /parts/)
+    end
+  end
+end

--- a/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
+++ b/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
@@ -73,29 +73,7 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
     end
   end
 
-  describe '.project_enrollment_counts' do
-    it 'counts enrollments per ProjectID, including zero for projects with none and projects only seen in Enrollment.csv' do
-      projects = [
-        ['P1', 'O1', 'One'],
-        ['P2', 'O1', 'Two'],
-        ['EMPTY', 'O2', 'No enrollments'],
-      ]
-      enrollments = [
-        ['E1', 'C1', 'P1'],
-        ['E2', 'C2', 'P1'],
-        ['E3', 'C3', 'P2'],
-        ['E4', 'C4', 'ORPHAN'],
-      ]
-      write_csv(source_path, 'Project.csv', ['ProjectID', 'OrganizationID', 'ProjectName'], projects)
-      write_csv(source_path, 'Enrollment.csv', ['EnrollmentID', 'PersonalID', 'ProjectID'], enrollments)
-
-      counts = described_class.project_enrollment_counts(source_path)
-
-      expect(counts).to eq('P1' => 2, 'P2' => 1, 'EMPTY' => 0, 'ORPHAN' => 1)
-    end
-  end
-
-  describe '.split_evenly' do
+  describe '#run!' do
     # 6 projects: P1 holds 12 of 16 enrollments, P2..P5 hold 1 each, P6 has none.
     # Expected grouping for 3 parts: [P1], [P2, P4, P6], [P3, P5].
     let(:projects) do
@@ -106,13 +84,14 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
       p1 + [['E2', 'C2', 'P2'], ['E3', 'C3', 'P3'], ['E4', 'C4', 'P4'], ['E5', 'C5', 'P5']]
     end
     let(:enrolled_client_ids) { enrollments.map { |row| row[1] } }
+    let(:enrollment_headers) { ['EnrollmentID', 'PersonalID', 'ProjectID'] }
 
     before do
       write_csv(source_path, 'Export.csv', ['ExportID', 'SourceType'], [['EX1', '3']])
       write_csv(source_path, 'User.csv', ['UserID', 'UserFirstName'], [['U1', 'Pat']])
       write_csv(source_path, 'Organization.csv', ['OrganizationID', 'OrganizationName'], [['O1', 'One'], ['O2', 'Two'], ['O3', 'Three']])
       write_csv(source_path, 'Project.csv', ['ProjectID', 'OrganizationID', 'ProjectName'], projects.map { |id, org| [id, org, id] })
-      write_csv(source_path, 'Enrollment.csv', ['EnrollmentID', 'PersonalID', 'ProjectID'], enrollments)
+      write_csv(source_path, 'Enrollment.csv', enrollment_headers, enrollments)
       write_csv(source_path, 'Client.csv', ['PersonalID', 'FirstName'], (enrolled_client_ids + ['UNENROLLED']).map { |id| [id, id] })
       write_csv(source_path, 'Exit.csv', ['ExitID', 'EnrollmentID', 'PersonalID'], enrollments.map { |e, c, _| ["X-#{e}", e, c] })
     end
@@ -121,8 +100,18 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
       File.join(destination_path, "part_#{index}")
     end
 
+    def run_splitter(**options)
+      splitter = described_class.new(source_path: source_path, destination_path: destination_path, **options)
+      splitter.run!
+      splitter
+    end
+
+    def column_by_part(filename, column, parts)
+      (1..parts).map { |i| read_column(File.join(part_dir(i), filename), column) }
+    end
+
     it 'writes one directory per part with the dominant project alone and the rest balanced' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+      run_splitter(parts: 3)
 
       expect(Dir.children(destination_path)).to contain_exactly('part_1', 'part_2', 'part_3')
       expect(read_column(File.join(part_dir(1), 'Project.csv'), 'ProjectID')).to contain_exactly('P1')
@@ -131,10 +120,10 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
     end
 
     it 'partitions enrollment-scoped rows so every source row appears in exactly one part' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+      run_splitter(parts: 3)
 
-      enrollment_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Enrollment.csv'), 'EnrollmentID') }
-      exit_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Exit.csv'), 'EnrollmentID') }
+      enrollment_ids_by_part = column_by_part('Enrollment.csv', 'EnrollmentID', 3)
+      exit_ids_by_part = column_by_part('Exit.csv', 'EnrollmentID', 3)
 
       expect(enrollment_ids_by_part.flatten).to contain_exactly(*enrollments.map(&:first))
       expect(enrollment_ids_by_part.map(&:size)).to eq([12, 2, 2])
@@ -142,7 +131,7 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
     end
 
     it 'limits Organization.csv in each part to the organizations of that part\'s projects' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+      run_splitter(parts: 3)
 
       expect(read_column(File.join(part_dir(1), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O1')
       expect(read_column(File.join(part_dir(2), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O1', 'O2', 'O3')
@@ -150,7 +139,7 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
     end
 
     it 'copies Export.csv and User.csv unchanged into every part' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+      run_splitter(parts: 3)
 
       (1..3).each do |i|
         expect(File.read(File.join(part_dir(i), 'Export.csv'))).to eq(File.read(File.join(source_path, 'Export.csv')))
@@ -159,37 +148,80 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
     end
 
     it 'excludes unenrolled clients from every part by default' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+      run_splitter(parts: 3)
 
-      client_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Client.csv'), 'PersonalID') }
-
-      expect(client_ids_by_part.flatten).to contain_exactly(*enrolled_client_ids)
+      expect(column_by_part('Client.csv', 'PersonalID', 3).flatten).to contain_exactly(*enrolled_client_ids)
     end
 
     it 'adds unenrolled clients to part 1 only when include_unenrolled_clients is true' do
-      described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3, include_unenrolled_clients: true)
+      run_splitter(parts: 3, include_unenrolled_clients: true)
 
-      client_ids_by_part = (1..3).map { |i| read_column(File.join(part_dir(i), 'Client.csv'), 'PersonalID') }
+      client_ids_by_part = column_by_part('Client.csv', 'PersonalID', 3)
 
-      expect(client_ids_by_part[0]).to include('UNENROLLED')
-      expect(client_ids_by_part[1]).not_to include('UNENROLLED')
-      expect(client_ids_by_part[2]).not_to include('UNENROLLED')
+      expect(client_ids_by_part.map { |ids| ids.include?('UNENROLLED') }).to eq([true, false, false])
       expect(client_ids_by_part.flatten).to contain_exactly(*enrolled_client_ids, 'UNENROLLED')
     end
 
-    it 'returns one run splitter per part so results can be reconciled against the source' do
-      splitters = described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 3)
+    it 'writes a client enrolled in projects from different parts to each of those parts' do
+      # C2 is enrolled in P2 (part 3) and P3 (part 2) once P3 gains a second enrollment.
+      # Grouping becomes [P1], [P3, P5], [P2, P4, P6].
+      write_csv(source_path, 'Enrollment.csv', enrollment_headers, enrollments + [['E6', 'C2', 'P3']])
 
-      expect(splitters.map(&:project_ids)).to eq([['P1'], ['P2', 'P4', 'P6'], ['P3', 'P5']])
-      added = splitters.sum { |s| s.results['Enrollment.csv'][:added] }
-      expect(added).to eq(enrollments.size)
-      expect(splitters.first.results['Enrollment.csv'][:original]).to eq(enrollments.size)
+      run_splitter(parts: 3)
+
+      client_ids_by_part = column_by_part('Client.csv', 'PersonalID', 3)
+      expect(client_ids_by_part.map { |ids| ids.include?('C2') }).to eq([false, true, true])
+      expect(read_column(File.join(part_dir(2), 'Project.csv'), 'ProjectID')).to contain_exactly('P3', 'P5')
+    end
+
+    it 'reports source, written, and per-part row counts for each file' do
+      splitter = run_splitter(parts: 3)
+
+      expect(splitter.results['Enrollment.csv']).to eq(original: 16, added: 16, by_part: [12, 2, 2])
+      expect(splitter.results['Project.csv']).to eq(original: 6, added: 6, by_part: [1, 3, 2])
+      expect(splitter.project_groups).to eq([['P1'], ['P2', 'P4', 'P6'], ['P3', 'P5']])
+    end
+
+    it 'restricts every file to the project_ids filter when parts is 1' do
+      splitter = run_splitter(project_ids: ['P2', 'P3'], parts: 1)
+
+      expect(Dir.children(destination_path)).to contain_exactly('part_1')
+      expect(read_column(File.join(part_dir(1), 'Project.csv'), 'ProjectID')).to contain_exactly('P2', 'P3')
+      expect(read_column(File.join(part_dir(1), 'Organization.csv'), 'OrganizationID')).to contain_exactly('O1', 'O2')
+      expect(read_column(File.join(part_dir(1), 'Enrollment.csv'), 'EnrollmentID')).to contain_exactly('E2', 'E3')
+      expect(read_column(File.join(part_dir(1), 'Exit.csv'), 'EnrollmentID')).to contain_exactly('E2', 'E3')
+      expect(read_column(File.join(part_dir(1), 'Client.csv'), 'PersonalID')).to contain_exactly('C2', 'C3')
+      expect(splitter.results['Enrollment.csv']).to eq(original: 16, added: 2, by_part: [2])
+    end
+
+    it 'balances only the filtered projects when project_ids and parts are both given' do
+      splitter = run_splitter(project_ids: ['P1', 'P2', 'P3'], parts: 2)
+
+      expect(splitter.project_groups).to eq([['P1'], ['P2', 'P3']])
+      expect(column_by_part('Project.csv', 'ProjectID', 2).flatten).to contain_exactly('P1', 'P2', 'P3')
+    end
+
+    it 'includes enrollments whose ProjectID is absent from Project.csv when there is no filter' do
+      write_csv(source_path, 'Enrollment.csv', enrollment_headers, enrollments + [['E9', 'C9', 'ORPHAN']])
+
+      splitter = run_splitter(parts: 1)
+
+      expect(read_column(File.join(part_dir(1), 'Enrollment.csv'), 'EnrollmentID')).to include('E9')
+      expect(splitter.results['Enrollment.csv']).to eq(original: 17, added: 17, by_part: [17])
+    end
+
+    it 'drops enrollments whose ProjectID is outside the filter' do
+      write_csv(source_path, 'Enrollment.csv', enrollment_headers, enrollments + [['E9', 'C9', 'ORPHAN']])
+
+      run_splitter(project_ids: ['P1'], parts: 1)
+
+      expect(read_column(File.join(part_dir(1), 'Enrollment.csv'), 'ProjectID').uniq).to eq(['P1'])
     end
 
     it 'raises ArgumentError when parts is not a positive integer' do
-      expect { described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: 0) }.
+      expect { described_class.new(source_path: source_path, destination_path: destination_path, parts: 0) }.
         to raise_error(ArgumentError, /parts/)
-      expect { described_class.split_evenly(source_path: source_path, destination_path: destination_path, parts: '3') }.
+      expect { described_class.new(source_path: source_path, destination_path: destination_path, parts: '3') }.
         to raise_error(ArgumentError, /parts/)
     end
   end

--- a/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
+++ b/spec/models/grda_warehouse/tasks/hmis_csv_splitter_spec.rb
@@ -9,25 +9,6 @@
 require 'rails_helper'
 
 RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
-  let(:source_path) { Dir.mktmpdir('splitter-source') }
-  let(:destination_path) { Dir.mktmpdir('splitter-dest') }
-
-  after do
-    FileUtils.rm_rf(source_path)
-    FileUtils.rm_rf(destination_path)
-  end
-
-  def write_csv(dir, filename, headers, rows)
-    CSV.open(File.join(dir, filename), 'wb') do |csv|
-      csv << headers
-      rows.each { |row| csv << row }
-    end
-  end
-
-  def read_column(path, column)
-    CSV.read(path, headers: true).map { |row| row[column] }
-  end
-
   describe '.balance_projects' do
     it 'isolates a dominant project and pairs the remaining projects across the other parts' do
       counts = { 'P1' => 75, 'P2' => 6, 'P3' => 6, 'P4' => 7, 'P5' => 6 }
@@ -74,6 +55,25 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
   end
 
   describe '#run!' do
+    let(:source_path) { Dir.mktmpdir('splitter-source') }
+    let(:destination_path) { Dir.mktmpdir('splitter-dest') }
+
+    after do
+      FileUtils.rm_rf(source_path)
+      FileUtils.rm_rf(destination_path)
+    end
+
+    def write_csv(dir, filename, headers, rows)
+      CSV.open(File.join(dir, filename), 'wb') do |csv|
+        csv << headers
+        rows.each { |row| csv << row }
+      end
+    end
+
+    def read_column(path, column)
+      CSV.read(path, headers: true).map { |row| row[column] }
+    end
+
     # 6 projects: P1 holds 12 of 16 enrollments, P2..P5 hold 1 each, P6 has none.
     # Expected grouping for 3 parts: [P1], [P2, P4, P6], [P3, P5].
     let(:projects) do
@@ -160,6 +160,12 @@ RSpec.describe GrdaWarehouse::Tasks::HmisCsvSplitter do
 
       expect(client_ids_by_part.map { |ids| ids.include?('UNENROLLED') }).to eq([true, false, false])
       expect(client_ids_by_part.flatten).to contain_exactly(*enrolled_client_ids, 'UNENROLLED')
+    end
+
+    it 'treats a client enrolled only in filtered-out projects as enrolled, not unenrolled, when include_unenrolled_clients is true' do
+      run_splitter(project_ids: ['P2'], parts: 1, include_unenrolled_clients: true)
+
+      expect(read_column(File.join(part_dir(1), 'Client.csv'), 'PersonalID')).to contain_exactly('C2', 'UNENROLLED')
     end
 
     it 'writes a client enrolled in projects from different parts to each of those parts' do


### PR DESCRIPTION
## _Merging this PR_
- use the squash-merge strategy for PRs targeting `main`

## Description
[//]: # (Summarize changes and include links related issue)
[//]: # (List any new dependencies or relevant ADRs)

* Adjusts `HmisCsvSplitter` so it can take a number of parts, the splitter then inspects the project and enrollment files, buckets projects such that each part gets roughly the same number of enrollments and then splits into the specified nubmer of parts.
* It still takes an array of ProjectIDs (optionally) which filter the entire split, so calling with `parts: 1, project_ids: ['P-1', 'P-2']` gives the same result as the previous version.

Confirmed identical output on a large file split with the old and new process.

## Type of change
[//]: # (e.g., Bug fix, New feature, Documentation, Code clean-up, Dependency update)

* New feature

## Checklist before requesting review
[//]: # (Remove any items that are not applicable)
- [x] I performed a self-review of my code
- [x] I ran the OP review skill
- [x] I ran the code that is being changed under ideal conditions, and it doesn't fail
- [ ] If adding a new endpoint / exposing data in a new way, I have:
  - [ ] ensured the API can't leak data from other data sources
  - [ ] ensured this does not introduce N+1s
  - [ ] ensured permissions and visibility checks are performed in the right places
- [ ] Any major architectural changes are supported by an approved ADR (Architectural Decision Record)
- [ ] I updated the documentation (or not applicable)
- [x] I added spec tests (or not applicable)
- [ ] I provided testing instructions in this PR or the related issue (or not applicable)

[//]: # (NOTE: system tests may fail if there is no branch on the hmis-frontend that matches the Source  or Target branch of this PR. This is expected)

